### PR TITLE
change to non-configurable

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,0 @@
-tests/fixtures/
-src/
-node_modules/
-package-lock.json
-package.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-	"plugins": ["prettier-plugin-svelte"],
-	"useTabs": true,
-	"printWidth": 100,
-	"singleQuote": true,
-	"bracketSpacing": false
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 Covers the npm packages published from this repo — `@fuzdev/tsv_format_wasm`,
 `@fuzdev/tsv_parse_wasm`, and `@fuzdev/tsv_wasm`. All move together at the
-`Cargo.toml [workspace.package]` version. `deno task publish --wetrun --bump <level>`
-converts the `## Unreleased` section into the released version's section.
+`Cargo.toml [workspace.package]` version. Each `## Unreleased` section must be
+non-empty and carry a `<!-- bump: patch|minor|major -->` marker; `deno task publish
+--wetrun --bump <level>` requires `<level>` to match it, then stamps the section
+(marker removed) into the released version's section and seeds a fresh empty
+`## Unreleased` (reset to `bump: patch`) for the next cycle.
 
 ## Unreleased
 <!-- bump: minor -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Covers the npm packages published from this repo — `@fuzdev/tsv_format_wasm`,
 converts the `## Unreleased` section into the released version's section.
 
 ## Unreleased
+<!-- bump: minor -->
 
 - formatting is now **non-configurable by design** — no config files, CLI flags,
   or runtime options, and none are planned (opinionated like `gofmt` and Black).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Covers the npm packages published from this repo — `@fuzdev/tsv_format_wasm`,
 `Cargo.toml [workspace.package]` version. `deno task publish --wetrun --bump <level>`
 converts the `## Unreleased` section into the released version's section.
 
+## Unreleased
+
+- formatting is now **non-configurable by design** — no config files, CLI flags,
+  or runtime options, and none are planned (opinionated like `gofmt` and Black).
+  Reverses the earlier "config options will come later" note in the docs. No
+  change to formatter output or the published API (`format_*` / `parse_*` / the
+  `tsv` bin) — a posture formalization plus removal of the internal config
+  plumbing that anticipated future options.
+
 ## 0.1.0
 
 - init

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,11 +216,11 @@ Version source of truth: `Cargo.toml` `[workspace.package] version` (read direct
 
 Package shape: built from the wasm-pack `web` target, then `scripts/patch_npm_package.ts` adds a Node/Bun entry (`index.js`, sync auto-init), a browser entry (`browser.js`, guarded `await init()`), `index.d.ts`, conditional `exports`, npm metadata, and the variant README. The export list is extracted from the generated JS, so new `lang_bindings!` languages flow through automatically.
 
-`scripts/publish.ts` orchestrates the release end to end (preflight → bump → check → build (npm packages + deno bundles, so artifact validation never sees stale bundles) → verify → artifact validation: size bounds + Deno smoke + Node tests → idempotent npm publish → git commit + tag + push), printing a wasm size summary (raw + gzipped) at the end. It converts CHANGELOG.md's `## Unreleased` section into the released version's section — keep that section updated as work lands. A failed wetrun is resumable: re-run `--wetrun` without `--bump`.
+`scripts/publish.ts` orchestrates the release end to end (preflight → bump → check → build (npm packages + deno bundles, so artifact validation never sees stale bundles) → verify → artifact validation: size bounds + Deno smoke + Node tests → idempotent npm publish → git commit + tag + push), printing a wasm size summary (raw + gzipped) at the end. It stamps CHANGELOG.md's `## Unreleased` section into the released version's section — that section must be non-empty and carry a `<!-- bump: <level> -->` marker that matches `--bump` (the bump is required in **both** places and they must agree; on stamp the marker is dropped and a fresh empty `## Unreleased` reset to `bump: patch` is seeded for the next cycle). Keep it updated as work lands. A failed wetrun is resumable: re-run `--wetrun` without `--bump`.
 
 ```bash
 deno task publish                        # dry-run: validate everything, no mutation
-deno task publish --wetrun --bump patch  # release: bump + publish + git finalize (--bump required)
+deno task publish --wetrun --bump patch  # release: bump + publish + git finalize (--bump required, must match CHANGELOG marker)
 deno task publish --wetrun               # resume a failed wetrun (sentinel retry only)
 # Flags: --bump patch|minor|major, --no-check, --no-git
 deno task test:npm[:parse|:all]          # Node tests against a built pkg/{format,parse,all}/npm/ (:all includes CLI tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,11 @@ deno task check          # typecheck + test + lint + fmt (full validation)
 deno task typecheck      # cargo check
 deno task test           # cargo test
 deno task lint           # cargo clippy
-cargo fmt                # format Rust code
+cargo fmt                # format Rust code — the only autoformatter in this repo
+# Non-Rust files (TS/MD/JSON) are hand-maintained: tsv ships NO prettier or deno
+# fmt config. Never run `deno fmt` or `prettier` on the repo — with no config they
+# reformat to their own defaults (spaces, double quotes) and churn every file. The
+# fixture/corpus prettier oracles pass options inline, so they're unaffected.
 
 cargo test --workspace test_typescript_parser_literal  # run specific test by name
 cargo test --workspace --test fixtures_tests           # fixture validation tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 High-performance Rust parser as a drop-in replacement for Svelte's modern parser (acorn + acorn-typescript) with a near-Prettier formatter that tracks Prettier closely.
 
-**Formatter configuration**: Hardcoded (print_width=100, tab_width=2, use_tabs=true). No config files or CLI flags. See [Configuration](#configuration).
+**Non-configurable by design**: formatting options are fixed at Prettier's defaults (print_width=100, tab_width=2, use_tabs=true) — no config files, CLI flags, or runtime options, ever (opinionated like `gofmt` and Black). See [Configuration](#configuration).
 
 ## Committing
 
@@ -305,7 +305,7 @@ See ./docs/performance.md.
 
 ## Configuration
 
-**No external configuration in 0.1.** All settings are hardcoded to match Prettier defaults. User-facing options (a narrower subset than Prettier's, but the same shape) are planned for a later release.
+**Non-configurable by design.** Formatting options are fixed at Prettier's defaults and cannot be changed — there are no config files, CLI flags, or runtime options, and none are planned. tsv is opinionated like `gofmt` and Black: one canonical style, always. A narrower user-facing option set may be revisited far down the road, but the 0.x contract is no configuration at all.
 
 | Setting       | Value | Notes                |
 | ------------- | ----- | -------------------- |
@@ -317,17 +317,18 @@ See ./docs/performance.md.
 
 ### Internal Configuration (Rust Library Only)
 
-Print width / tab width / indent are compile-time `pub const`s in `tsv_lang::config` (`PRINT_WIDTH`, `TAB_WIDTH`, `INDENT`) — not config struct fields. Programmatic customization is split across three types:
+There is no runtime configuration. Print width / tab width / indent are compile-time `pub const`s in `tsv_lang::config` (`PRINT_WIDTH`, `TAB_WIDTH`, `INDENT`), read directly by the renderer — not threaded through any signature. Quote preference is likewise hardcoded (single quotes) inside `tsv_lang::printing::format_string_literal`. The doc-builder unit tests exercise the layout at smaller widths via the internal `RenderConfig` seam (`doc::render_config`, `pub(crate)`), never at runtime.
 
-- `tsv_lang::PrintConfig` — reserved slot for future workspace-wide doc-builder toggles. Empty today; the type and its threading are in place so future cross-language options slot in without signature churn.
+Two types carry genuine per-input *state* (not configuration), threaded only where they vary:
+
 - `tsv_lang::EmbedContext { base_indent_offset, first_line_offset, suffix_width, mode: LayoutMode }` — embedding state for nested formatting (CSS in `<style>`, Svelte template expressions). `LayoutMode { Standalone, Embedded }` controls binary-expression indent style.
-- `tsv_ts::TsConfig` — TypeScript-specific knobs (`arrow_type_param_trailing_comma`). Default is pure-TS (`false`); use `TsConfig::svelte()` when embedding TS in a Svelte file so `<T>` arrow type params get the disambiguating trailing comma.
+- `tsv_ts::TsContext { Standalone, Svelte }` — whether the TypeScript is standalone or embedded in a Svelte file. Derived from the file kind, not a user option; `TsContext::Svelte` enables `<T,>` arrow-type-param disambiguation. `tsv_svelte` passes it when embedding TS.
 
 ```rust
-use tsv_ts::{TsConfig, format, format_with_config};
+use tsv_ts::{TsContext, format, format_with_context};
 
-let formatted = format(&ast, source);                                   // pure TS
-let formatted = format_with_config(&ast, source, TsConfig::svelte());   // Svelte context
+let formatted = format(&ast, source);                                   // pure TS (Standalone)
+let formatted = format_with_context(&ast, source, TsContext::Svelte);   // Svelte-embedded TS
 ```
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const ast: Root = parse_svelte('<script>const x = 1;</script>');
 ```
 
 Both halves import the same way from `@fuzdev/tsv_wasm`.
-Works zero-config in Node.js/Bun/Deno (sync auto-init);
+Works without setup in Node.js/Bun/Deno (sync auto-init);
 browsers and bundlers must call `await init()` once first.
 See the package READMEs for the full API and CLI flags:
 
@@ -75,10 +75,10 @@ from anything that speaks C FFI. Deno's FFI is used in the benchmarks.
   code size are first-class goals for every shipped artifact, and heavier future
   layers (incremental parsing, CST for LSP) will be feature-gated so they
   don't regress the artifacts that exist today
-- minimal configuration for now: formatter settings are hardcoded
+- non-configurable by design: formatter settings are fixed at Prettier's defaults
   (`print_width: 100`, `tab_width: 2`, `use_tabs: true`,
-  and `bracketSpacing: false` which may be a bad choice that came from the author's preference);
-  config files and CLI options will come later -
+  and `bracketSpacing: false` which may be a bad choice that came from the author's preference)
+  and there are no config files or CLI options - tsv is opinionated like `gofmt` and Black -
   see [CLAUDE.md § Configuration](CLAUDE.md#configuration),
   and discussions/requests are welcome
 - JS and TS always parse as modules in strict mode - sloppy-mode-only syntax

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AI disclosure: this codebase was generated with machine agents.
 The first release took 7 months and ~1800 manual commits.
 Significant effort went into design and quality
 (I think refactoring and quality were well over half of the token spend),
-but the docs are in rough shape and the usual LLM caveats apply.
+but the usual LLM caveats apply.
 
 ## Install
 

--- a/benches/deno/CLAUDE.md
+++ b/benches/deno/CLAUDE.md
@@ -442,6 +442,16 @@ Things the published numbers measure that aren't quite what they look like:
 
 ## Corpus
 
+~5,500 files (~15 MB) of real `.svelte`, `.ts`/`.js`, and `.css` from three
+sources (this framing is the source of truth for the public benchmark page's
+"What's measured" prose — keep them in sync):
+
+1. **Application & library source** — the fuz.dev repos (`src/` of real projects).
+2. **Upstream framework source** — Svelte, SvelteKit, and the svelte.dev site.
+3. **Formatter conformance fixtures** — Prettier's and prettier-plugin-svelte's
+   own test suites (deliberately tricky edge cases, not typical code — they skew
+   the corpus toward hard cases).
+
 Paths defined in `lib/corpus.ts` `DEFAULT_CORPUS_PATHS`, relative to project root:
 
 - zzz (large apps)

--- a/benches/deno/lib/binary_sizes.ts
+++ b/benches/deno/lib/binary_sizes.ts
@@ -10,6 +10,9 @@
 
 import type { AllVersions } from './versions.ts';
 
+/** Binary kind for grouping comparisons */
+export type BinaryKind = 'wasm' | 'native';
+
 /** A collected binary size entry */
 export interface BinarySize {
 	/** Display label */
@@ -23,8 +26,25 @@ export interface BinarySize {
 	 */
 	gzip_bytes: number | null;
 	/** Binary kind for grouping comparisons */
-	kind: 'wasm' | 'native';
+	kind: BinaryKind;
 }
+
+/**
+ * Display labels — also the identity keys for the ratio-anchor lookups in
+ * `build_display_entries`, so the producer (`collect_binary_sizes`) and the
+ * consumer must reference the same constant. Renaming a label here updates both.
+ */
+const LABELS = {
+	tsv_native: 'tsv (native)',
+	tsv_format_wasm: 'tsv_format_wasm',
+	tsv_parse_wasm: 'tsv_parse_wasm',
+	tsv_wasm: 'tsv_wasm',
+	biome_wasm: 'biome (wasm)',
+	oxc_parser_native: 'oxc-parser (native)',
+	oxfmt_native: 'oxfmt (native)',
+	oxc_parser_wasm: 'oxc-parser (wasm)',
+	oxc_combined_native: 'oxc-parser+oxfmt (native)',
+} as const;
 
 /** Get the Deno npm cache base path */
 function get_deno_npm_cache_path(): string {
@@ -81,7 +101,7 @@ type StagedEntry = { entry: Omit<BinarySize, 'gzip_bytes'>; path: string };
 async function push_size(
 	out: StagedEntry[],
 	label: string,
-	kind: 'wasm' | 'native',
+	kind: BinaryKind,
 	path: string,
 ): Promise<void> {
 	const bytes = await file_size(path);
@@ -107,6 +127,36 @@ async function resolve_first(
 		}
 	}
 	return null;
+}
+
+/** Stage an entry resolved by scanning `dirs` for the first file ending in `ext`. */
+async function push_resolved(
+	out: StagedEntry[],
+	label: string,
+	kind: BinaryKind,
+	dirs: string[],
+	ext: string,
+): Promise<void> {
+	const found = await resolve_first(dirs, ext);
+	if (found !== null) out.push({ entry: { label, bytes: found.bytes, kind }, path: found.path });
+}
+
+/**
+ * Candidate cache dirs for a NAPI native binding, newest layout first. npm
+ * ships per-libc variants (`-gnu`, `-musl`) plus a libc-agnostic fallback.
+ */
+function napi_binding_dirs(
+	npm_cache: string,
+	scope_pkg: string,
+	os: string,
+	arch: string,
+	version: string,
+): string[] {
+	return [
+		`${npm_cache}/${scope_pkg}-${os}-${arch}-gnu/${version}`,
+		`${npm_cache}/${scope_pkg}-${os}-${arch}-musl/${version}`,
+		`${npm_cache}/${scope_pkg}-${os}-${arch}/${version}`,
+	];
 }
 
 /**
@@ -139,7 +189,7 @@ export async function collect_binary_sizes(
 		const prefix = Deno.build.os === 'windows' ? '' : 'lib';
 		await push_size(
 			staged,
-			'tsv',
+			LABELS.tsv_native,
 			'native',
 			`${project_root}/target/release/${prefix}tsv_ffi.${ext}`,
 		);
@@ -152,19 +202,19 @@ export async function collect_binary_sizes(
 	if (options?.has_wasm !== false) {
 		await push_size(
 			staged,
-			'tsv_format_wasm',
+			LABELS.tsv_format_wasm,
 			'wasm',
 			`${project_root}/crates/tsv_wasm/pkg/format/deno/tsv_wasm_bg.wasm`,
 		);
 		await push_size(
 			staged,
-			'tsv_parse_wasm',
+			LABELS.tsv_parse_wasm,
 			'wasm',
 			`${project_root}/crates/tsv_wasm/pkg/parse/deno/tsv_wasm_bg.wasm`,
 		);
 		await push_size(
 			staged,
-			'tsv_wasm',
+			LABELS.tsv_wasm,
 			'wasm',
 			`${project_root}/crates/tsv_wasm/pkg/all/deno/tsv_wasm_bg.wasm`,
 		);
@@ -172,14 +222,13 @@ export async function collect_binary_sizes(
 
 	// biome WASM
 	if (options?.has_biome !== false) {
-		const biome_dir = `${npm_cache}/@biomejs/wasm-bundler/${versions.biome.wasm}`;
-		const found = await resolve_first([biome_dir], '.wasm');
-		if (found !== null) {
-			staged.push({
-				entry: { label: 'biome (wasm)', bytes: found.bytes, kind: 'wasm' },
-				path: found.path,
-			});
-		}
+		await push_resolved(
+			staged,
+			LABELS.biome_wasm,
+			'wasm',
+			[`${npm_cache}/@biomejs/wasm-bundler/${versions.biome.wasm}`],
+			'.wasm',
+		);
 	}
 
 	// oxc-parser + oxfmt
@@ -188,44 +237,31 @@ export async function collect_binary_sizes(
 		const oxc_ver = versions.oxc['oxc-parser'];
 		const oxfmt_ver = versions.oxc.oxfmt;
 
-		const oxc_dirs = [
-			`${npm_cache}/@oxc-parser/binding-${os}-${arch}-gnu/${oxc_ver}`,
-			`${npm_cache}/@oxc-parser/binding-${os}-${arch}-musl/${oxc_ver}`,
-			`${npm_cache}/@oxc-parser/binding-${os}-${arch}/${oxc_ver}`,
-		];
-		const oxc_found = await resolve_first(oxc_dirs, '.node');
-		if (oxc_found !== null) {
-			staged.push({
-				entry: { label: 'oxc-parser (native)', bytes: oxc_found.bytes, kind: 'native' },
-				path: oxc_found.path,
-			});
-		}
+		await push_resolved(
+			staged,
+			LABELS.oxc_parser_native,
+			'native',
+			napi_binding_dirs(npm_cache, '@oxc-parser/binding', os, arch, oxc_ver),
+			'.node',
+		);
 
 		// oxfmt native binding (0.50.0+: @oxfmt/binding-{platform}; pre-0.49: @oxfmt/{platform}).
-		const oxfmt_dirs = [
-			`${npm_cache}/@oxfmt/binding-${os}-${arch}-gnu/${oxfmt_ver}`,
-			`${npm_cache}/@oxfmt/binding-${os}-${arch}-musl/${oxfmt_ver}`,
-			`${npm_cache}/@oxfmt/binding-${os}-${arch}/${oxfmt_ver}`,
-		];
-		const oxfmt_found = await resolve_first(oxfmt_dirs, '.node');
-		if (oxfmt_found !== null) {
-			staged.push({
-				entry: { label: 'oxfmt (native)', bytes: oxfmt_found.bytes, kind: 'native' },
-				path: oxfmt_found.path,
-			});
-		}
+		await push_resolved(
+			staged,
+			LABELS.oxfmt_native,
+			'native',
+			napi_binding_dirs(npm_cache, '@oxfmt/binding', os, arch, oxfmt_ver),
+			'.node',
+		);
 
 		// oxc-parser WASM binding (@oxc-parser/binding-wasm32-wasi)
-		const oxc_wasm_found = await resolve_first(
+		await push_resolved(
+			staged,
+			LABELS.oxc_parser_wasm,
+			'wasm',
 			[`${npm_cache}/@oxc-parser/binding-wasm32-wasi/${oxc_ver}`],
 			'.wasm',
 		);
-		if (oxc_wasm_found !== null) {
-			staged.push({
-				entry: { label: 'oxc-parser (wasm)', bytes: oxc_wasm_found.bytes, kind: 'wasm' },
-				path: oxc_wasm_found.path,
-			});
-		}
 	}
 
 	// Stage 2: gzip every collected file in parallel.
@@ -256,12 +292,10 @@ function build_display_entries(sizes: BinarySize[]): {
 	wasm_entries: DisplayRow[];
 	native_entries: DisplayRow[];
 } {
-	const tsv_native = sizes.find((s) => s.label === 'tsv');
-	// "vs tsv" wasm anchor: the flagship full build (`tsv_wasm`, the artifact
-	// the bench executes), falling back to the format subset for reports
-	// generated before shape v2 added the third build.
-	const tsv_wasm = sizes.find((s) => s.label === 'tsv_wasm') ??
-		sizes.find((s) => s.label === 'tsv_format_wasm');
+	const tsv_native = sizes.find((s) => s.label === LABELS.tsv_native);
+	// "vs tsv" wasm anchor: the flagship full build (`tsv_wasm`), the artifact
+	// the bench executes.
+	const tsv_wasm = sizes.find((s) => s.label === LABELS.tsv_wasm);
 
 	const wasm_sizes = sizes.filter((s) => s.kind === 'wasm');
 	const native_sizes = sizes.filter((s) => s.kind === 'native');
@@ -270,11 +304,11 @@ function build_display_entries(sizes: BinarySize[]): {
 	// the sum of the parts' gzipped sizes; that overstates wire size slightly
 	// (two streams don't share a dictionary) but matches how npm ships them
 	// — each binding is its own tarball.
-	const oxc_parser = native_sizes.find((s) => s.label === 'oxc-parser (native)');
-	const oxfmt_entry = native_sizes.find((s) => s.label === 'oxfmt (native)');
+	const oxc_parser = native_sizes.find((s) => s.label === LABELS.oxc_parser_native);
+	const oxfmt_entry = native_sizes.find((s) => s.label === LABELS.oxfmt_native);
 	const combined_oxc: BinarySize | null = oxc_parser && oxfmt_entry
 		? {
-			label: 'oxc-parser+oxfmt (native)',
+			label: LABELS.oxc_combined_native,
 			bytes: oxc_parser.bytes + oxfmt_entry.bytes,
 			gzip_bytes: oxc_parser.gzip_bytes !== null && oxfmt_entry.gzip_bytes !== null
 				? oxc_parser.gzip_bytes + oxfmt_entry.gzip_bytes

--- a/benches/deno/lib/canonical.ts
+++ b/benches/deno/lib/canonical.ts
@@ -17,50 +17,28 @@ interface PrettierModule {
 	format: (source: string, options: Record<string, unknown>) => Promise<string>;
 }
 
-/** Prettier config options we care about */
-interface PrettierConfig {
-	useTabs?: boolean;
-	printWidth?: number;
-	singleQuote?: boolean;
-	bracketSpacing?: boolean;
-}
-
 /** Parser function type */
 type ParserFn = (source: string) => unknown;
 
 /**
- * Load prettier config from .prettierrc.json at project root.
- * Falls back to defaults if file not found.
+ * Prettier formatting options, fixed to tsv's settings and passed explicitly on
+ * every call. Mirrors the inline options in the fixture oracle
+ * (`crates/tsv_debug/src/deno/sidecar.ts`), the source of truth for fixture
+ * correctness — tsv ships no prettier config file, so the corpus oracle reads
+ * none either. Keep these two option sets identical.
  */
-async function load_prettier_config(): Promise<PrettierConfig> {
-	const config_path = new URL('../../../.prettierrc.json', import.meta.url).pathname;
-	try {
-		const content = await Deno.readTextFile(config_path);
-		const config = JSON.parse(content);
-		// Extract only the options we care about (not plugins - we handle those separately)
-		return {
-			useTabs: config.useTabs,
-			printWidth: config.printWidth,
-			singleQuote: config.singleQuote,
-			bracketSpacing: config.bracketSpacing,
-		};
-	} catch {
-		// Fall back to defaults matching our .prettierrc.json
-		return {
-			useTabs: true,
-			printWidth: 100,
-			singleQuote: true,
-			bracketSpacing: false,
-		};
-	}
-}
+const PRETTIER_OPTIONS = {
+	useTabs: true,
+	printWidth: 100,
+	singleQuote: true,
+	bracketSpacing: false,
+} as const;
 
 export class CanonicalImplementation implements TsvImplementation {
 	name = 'canonical' as const;
 	readonly versions: CanonicalVersions;
 
 	#prettier: PrettierModule | null = null;
-	#prettier_config: PrettierConfig = {};
 	// deno-lint-ignore no-explicit-any
 	#prettier_svelte: any = null;
 	// deno-lint-ignore no-explicit-any
@@ -85,23 +63,20 @@ export class CanonicalImplementation implements TsvImplementation {
 	}
 
 	async init(): Promise<void> {
-		// Load config and dependencies in parallel
+		// Load dependencies in parallel
 		const [
-			prettier_config,
 			prettier_mod,
 			prettier_svelte_mod,
 			svelte_mod,
 			acorn_mod,
 			acorn_ts_mod,
 		] = await Promise.all([
-			load_prettier_config(),
 			import('prettier'),
 			import('prettier-plugin-svelte'),
 			import('svelte/compiler'),
 			import('acorn'),
 			import('@sveltejs/acorn-typescript'),
 		]);
-		this.#prettier_config = prettier_config;
 		this.#prettier = prettier_mod as PrettierModule;
 		this.#prettier_svelte = prettier_svelte_mod;
 		this.#svelte_compiler = svelte_mod;
@@ -160,7 +135,7 @@ export class CanonicalImplementation implements TsvImplementation {
 			parser: LANGUAGE_PRETTIER_PARSERS[language],
 			filepath: `file${LANGUAGE_EXTENSIONS[language]}`,
 			plugins,
-			...this.#prettier_config,
+			...PRETTIER_OPTIONS,
 		});
 	}
 

--- a/benches/deno/lib/canonical_test.ts
+++ b/benches/deno/lib/canonical_test.ts
@@ -47,7 +47,7 @@ Deno.test('canonical: single-type-param arrow keeps `<T,>` in .svelte (JSX disam
 	const impl = await make_canonical();
 	try {
 		// In a Svelte `<script lang="ts">`, `<T>` is ambiguous with template syntax, so the
-		// disambiguating comma is correct — mirroring tsv's `TsConfig::svelte()`.
+		// disambiguating comma is correct — mirroring tsv's `TsContext::Svelte`.
 		const out = await impl.format_async(
 			'<script lang="ts">\n\tconst f = <T>(x: T) => x;\n</script>\n',
 			'svelte',

--- a/benches/deno/results/report.json
+++ b/benches/deno/results/report.json
@@ -19,7 +19,7 @@
 	},
 	"binary_sizes": [
 		{
-			"label": "tsv",
+			"label": "tsv (native)",
 			"bytes": 3861760,
 			"kind": "native",
 			"gzip_bytes": 1622771

--- a/benches/deno/results/report.md
+++ b/benches/deno/results/report.md
@@ -123,7 +123,7 @@ _Note: every `Nx` is speedup form — values > 1 mean self is faster. File count
 | tsv_wasm                  |  2.9 MB | 911.3 KB |      — |           — |
 | biome (wasm)              | 34.4 MB |   8.2 MB |  11.9x |        9.0x |
 | oxc-parser (wasm)         |  1.9 MB | 518.7 KB |   0.6x |        0.6x |
-| tsv                       |  3.9 MB |   1.6 MB |      — |           — |
+| tsv (native)              |  3.9 MB |   1.6 MB |      — |           — |
 | oxc-parser+oxfmt (native) | 10.7 MB |   4.3 MB |   2.8x |        2.6x |
 | oxc-parser (native)       |  2.7 MB |   1.0 MB |   0.7x |        0.6x |
 | oxfmt (native)            |  8.0 MB |   3.2 MB |   2.1x |        2.0x |

--- a/crates/tsv_css/CLAUDE.md
+++ b/crates/tsv_css/CLAUDE.md
@@ -8,7 +8,7 @@ Depends on `tsv_lang` for shared primitives (spans, doc builder, comments, embed
 
 **Sources of truth**: Svelte's `parseCss` defines the public AST shape; Prettier's `css` printer defines formatter output. Both are checked at fixture-validation time.
 
-Standard `ast/lexer/parser/printer` crate layout — see [root CLAUDE.md §Project Structure](../../CLAUDE.md#project-structure) and [`tsv_lang/CLAUDE.md`](../tsv_lang/CLAUDE.md) for the cross-cutting types (`DocArena`, `Span`, `PrintConfig`, `EmbedContext`). Public/internal AST split follows the workspace convention — see [root CLAUDE.md §AST Architecture](../../CLAUDE.md#ast-architecture-internal-vs-public).
+Standard `ast/lexer/parser/printer` crate layout — see [root CLAUDE.md §Project Structure](../../CLAUDE.md#project-structure) and [`tsv_lang/CLAUDE.md`](../tsv_lang/CLAUDE.md) for the cross-cutting types (`DocArena`, `Span`, `EmbedContext`). Public/internal AST split follows the workspace convention — see [root CLAUDE.md §AST Architecture](../../CLAUDE.md#ast-architecture-internal-vs-public).
 
 ## Public API
 
@@ -23,7 +23,7 @@ Standard `ast/lexer/parser/printer` crate layout — see [root CLAUDE.md §Proje
 **Embedding** (used by `tsv_svelte` for `<style>` blocks):
 
 - `parse_embedded(source, base_offset) -> Result<CssStyleSheet>` — same parser, but span positions are shifted by `base_offset` so they index into the parent Svelte file
-- `format_with_config(&stylesheet, source, PrintConfig, EmbedContext)` — formats with `EmbedContext::base_indent_offset` so wrapped lines respect outer Svelte indentation
+- `format_embedded(&stylesheet, source, EmbedContext)` — formats with `EmbedContext::base_indent_offset` so wrapped lines respect outer Svelte indentation
 
 The two `StyleSheet` / `StyleContent` types (re-exported only with `convert`) are the public-AST envelopes `tsv_svelte` uses when embedding CSS in a `<style>` element's JSON. Distinct from `CssStyleSheet` (the internal AST root) and `CssNode` (the top-level statement enum).
 

--- a/crates/tsv_css/src/lib.rs
+++ b/crates/tsv_css/src/lib.rs
@@ -75,33 +75,32 @@ pub fn format(stylesheet: &CssStyleSheet, source: &str) -> String {
     printer::format_css(stylesheet, source)
 }
 
-/// Format CSS stylesheet with custom configuration
+/// Format a CSS stylesheet embedded in another language (e.g., Svelte).
 ///
-/// Use this when CSS is nested inside another language (e.g., Svelte)
-/// with base_indent_offset to account for wrapper indentation.
+/// Pass an [`EmbedContext`](tsv_lang::EmbedContext) with `base_indent_offset`
+/// so wrapped lines respect the host's indentation.
 ///
 /// # Arguments
 /// * `stylesheet` - CSS stylesheet (nodes + value comments)
 /// * `source` - Original CSS source code (for blank line preservation)
-/// * `config` - Print configuration with optional base_indent_offset
+/// * `embed` - Embedding context (e.g., `base_indent_offset`)
 ///
 /// # Example
 /// ```
-/// use tsv_css::{parse, format_with_config};
-/// use tsv_lang::{EmbedContext, PrintConfig};
+/// use tsv_css::{parse, format_embedded};
+/// use tsv_lang::EmbedContext;
 ///
 /// let css = "div{color:red;}";
 /// let stylesheet = parse(css).expect("Failed to parse CSS");
 /// let embed = EmbedContext { base_indent_offset: 1, ..EmbedContext::default() };
-/// let formatted = format_with_config(&stylesheet, css, PrintConfig::default(), embed);
+/// let formatted = format_embedded(&stylesheet, css, embed);
 /// ```
-pub fn format_with_config(
+pub fn format_embedded(
     stylesheet: &CssStyleSheet,
     source: &str,
-    config: tsv_lang::PrintConfig,
     embed: tsv_lang::EmbedContext,
 ) -> String {
-    printer::format_css_with_config(stylesheet, source, config, embed)
+    printer::format_css_embedded(stylesheet, source, embed)
 }
 
 /// Convert CSS AST to public JSON-compatible AST

--- a/crates/tsv_css/src/printer/mod.rs
+++ b/crates/tsv_css/src/printer/mod.rs
@@ -28,7 +28,7 @@ mod values;
 
 use crate::ast::internal::{Comment, CssBlockChild, CssNode, CssStyleSheet, CssValue};
 use tsv_lang::{
-    CommentPosition, EmbedContext, OutputBuffer, PrintConfig, classify_comment_fast,
+    CommentPosition, EmbedContext, OutputBuffer, classify_comment_fast,
     doc::{
         self,
         arena::{DocArena, DocId},
@@ -53,10 +53,6 @@ pub(crate) struct Printer<'a> {
     buffer: OutputBuffer,
     /// Current indentation level
     pub(crate) indent_level: usize,
-    /// Workspace-wide doc-builder configuration (reserved slot for future
-    /// cross-language toggles — empty today).
-    #[allow(dead_code)]
-    pub(crate) config: PrintConfig,
     /// Embedding context (base indent offset, first-line offset, layout mode, etc.).
     pub(crate) embed: EmbedContext,
     /// Arena allocator for doc nodes
@@ -72,27 +68,19 @@ pub(crate) struct Printer<'a> {
 impl<'a> Printer<'a> {
     /// Create a new printer with source, comments, and line_breaks
     pub(crate) fn new(source: &'a str, comments: &'a [Comment], line_breaks: &'a [u32]) -> Self {
-        Self::with_config(
-            source,
-            comments,
-            line_breaks,
-            PrintConfig::default(),
-            EmbedContext::default(),
-        )
+        Self::with_embed(source, comments, line_breaks, EmbedContext::default())
     }
 
-    /// Create a new printer with the given doc-builder config and embed context.
-    pub(crate) fn with_config(
+    /// Create a new printer with the given embedding context.
+    pub(crate) fn with_embed(
         source: &'a str,
         comments: &'a [Comment],
         line_breaks: &'a [u32],
-        config: PrintConfig,
         embed: EmbedContext,
     ) -> Self {
         Self {
             buffer: OutputBuffer::with_capacity(source.len()),
             indent_level: 0,
-            config,
             embed,
             arena: DocArena::for_source(source),
             source,
@@ -585,22 +573,15 @@ pub(crate) fn format_css(stylesheet: &CssStyleSheet, source: &str) -> String {
     printer.into_string()
 }
 
-/// Format CSS stylesheet with custom configuration
-/// Use this when CSS is nested inside another language (e.g., Svelte)
-/// with `embed.base_indent_offset` to account for wrapper indentation.
-pub(crate) fn format_css_with_config(
+/// Format a CSS stylesheet embedded in another language (e.g., Svelte), using
+/// `embed.base_indent_offset` to account for the host's wrapper indentation.
+pub(crate) fn format_css_embedded(
     stylesheet: &CssStyleSheet,
     source: &str,
-    config: PrintConfig,
     embed: EmbedContext,
 ) -> String {
-    let mut printer = Printer::with_config(
-        source,
-        &stylesheet.comments,
-        &stylesheet.line_breaks,
-        config,
-        embed,
-    );
+    let mut printer =
+        Printer::with_embed(source, &stylesheet.comments, &stylesheet.line_breaks, embed);
     printer.print_css_nodes(&stylesheet.nodes);
     printer.into_string()
 }

--- a/crates/tsv_css/src/printer/value_normalization.rs
+++ b/crates/tsv_css/src/printer/value_normalization.rs
@@ -6,7 +6,7 @@
 
 use crate::ast::internal::{Color, ColorChannel};
 use tsv_lang::Span;
-use tsv_lang::printing::{StringFormatOptions, format_string_literal};
+use tsv_lang::printing::format_string_literal;
 
 /// Format an identifier value semantically
 ///
@@ -467,7 +467,7 @@ pub(crate) fn format_color_from_source(color: &Color, source: &str, span: Span) 
 /// assert_eq!(format_string_value("world", '"'), "\"world\"");
 /// ```
 pub(crate) fn format_string_value(content: &str, quote: char) -> String {
-    format_string_literal(content, quote, StringFormatOptions::default())
+    format_string_literal(content, quote)
 }
 
 /// Extract and normalize property name from declaration source
@@ -550,8 +550,7 @@ pub(crate) fn extract_string_value(decl_source: &str, quote: char) -> Option<Str
         // String should be quoted
         if value_part.len() >= 2 {
             let raw_content = &value_part[1..value_part.len() - 1];
-            let formatted =
-                format_string_literal(raw_content, quote, StringFormatOptions::default());
+            let formatted = format_string_literal(raw_content, quote);
             return Some(formatted);
         }
     }

--- a/crates/tsv_lang/CLAUDE.md
+++ b/crates/tsv_lang/CLAUDE.md
@@ -13,7 +13,7 @@ The Visibility column reflects `pub use`-only modules (private) vs directly-impo
 | `span`        | `span.rs`        | private    | `Span { start: u32, end: u32 }` — compact source positions                                      |
 | `location`    | `location.rs`    | private    | `LocationTracker` — lazy line/column via O(log n) binary search                                 |
 | `error`       | `error.rs`       | private    | `ParseError` with context extraction and caret formatting                                       |
-| `config`      | `config.rs`      | private    | `PRINT_WIDTH` / `TAB_WIDTH` / `INDENT` consts + `PrintConfig` + `EmbedContext` / `LayoutMode`   |
+| `config`      | `config.rs`      | private    | `PRINT_WIDTH` / `TAB_WIDTH` / `INDENT` consts + `EmbedContext` / `LayoutMode` (no runtime config) |
 | `doc`         | `doc/*.rs`       | **pub**    | **Document builder** — arena-based Prettier-compatible IR                                       |
 | `comment`     | `comment.rs`     | private    | Comment type, classification, and O(log n) range lookup                                         |
 | `printing`    | `printing.rs`    | **pub**    | String literal formatting, same-line detection, visual width                                    |
@@ -147,6 +147,6 @@ String interning deduplicates identifiers across all languages in a file. Symbol
 
 ## Config Types
 
-`PRINT_WIDTH` / `TAB_WIDTH` / `INDENT` consts, `PrintConfig`, `EmbedContext`, and `LayoutMode` are covered in [../../CLAUDE.md §Internal Configuration](../../CLAUDE.md#internal-configuration-rust-library-only). Per-language knobs live on the language crate's own config (e.g., `tsv_ts::TsConfig`).
+`PRINT_WIDTH` / `TAB_WIDTH` / `INDENT` consts, `EmbedContext`, and `LayoutMode` are covered in [../../CLAUDE.md §Internal Configuration](../../CLAUDE.md#internal-configuration-rust-library-only). tsv has no runtime configuration; the standalone-vs-Svelte TypeScript distinction lives on `tsv_ts::TsContext`.
 
 **Embedding knobs**: `base_indent_offset` and `first_line_offset` are how tsv_svelte tells tsv_ts/tsv_css to format at the right indentation level within a Svelte component. `LayoutMode::Embedded` selects ContinuationIndent style for binary expressions (matches Prettier's `JsExpressionRoot` parent → `shouldNotIndent = true` semantics).

--- a/crates/tsv_lang/src/config.rs
+++ b/crates/tsv_lang/src/config.rs
@@ -1,10 +1,21 @@
-// Shared print configuration across all formatters
+//! Hardcoded formatter settings shared across all language printers.
+//!
+//! tsv is **non-configurable**: formatting options are fixed at Prettier's
+//! defaults and cannot be changed — there are no config files, CLI flags, or
+//! runtime options (like `gofmt` or Black). The constants below are the single
+//! source of truth for those fixed options; the renderer reads them directly,
+//! so nothing is threaded through call signatures.
+//!
+//! Runtime *state* that genuinely varies per input is not configuration and
+//! lives on dedicated context types: embedding offsets / layout mode on
+//! [`EmbedContext`] here, and the standalone-vs-Svelte TypeScript distinction
+//! on `tsv_ts::TsContext`.
 
 /// Maximum line width used by the formatter (matches Prettier default).
 ///
-/// Hardcoded — see [`crate::config`] module docs and the project README.
-/// The renderer reads this constant directly; tests override widths via
-/// the `*_with_widths` rendering helpers.
+/// The renderer reads this constant directly; the doc-builder unit tests
+/// exercise the layout at smaller widths via the internal `RenderConfig` seam
+/// (`doc::render_config`), never at runtime.
 pub const PRINT_WIDTH: usize = 100;
 
 /// Visual width of a single tab character, used for column calculations.
@@ -15,21 +26,7 @@ pub const TAB_WIDTH: usize = 2;
 /// `"\t"` matches the project's tabs-only indentation policy.
 pub const INDENT: &str = "\t";
 
-/// Workspace-wide doc-builder configuration.
-///
-/// Currently empty: the renderer reads compile-time globals ([`PRINT_WIDTH`] /
-/// [`TAB_WIDTH`] / [`INDENT`]) directly, embedding state lives on
-/// [`EmbedContext`], and language-specific knobs live on the language's own
-/// config (e.g., `tsv_ts::TsConfig`). This type is the reserved slot for
-/// cross-language doc-builder toggles that will appear when the hardcoded
-/// pre-v0.1 posture relaxes — future Prettier-style options that apply to
-/// every language go here.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct PrintConfig {}
-
 /// How the renderer should treat the doc tree at its outer boundary.
-///
-/// Replaces the old `PrintConfig::is_embedded_expression: bool`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LayoutMode {
     /// The doc tree is the entire document (e.g., a standalone TS/CSS file,
@@ -43,14 +40,10 @@ pub enum LayoutMode {
     Embedded,
 }
 
-/// Embedding state for a render. Threaded into the renderer alongside the
-/// doc tree; replaces the `base_indent_offset` / `first_line_offset` /
-/// `suffix_width` / `is_embedded_expression` fields previously on
-/// [`PrintConfig`].
-///
-/// Constructed by the host language (e.g., tsv_svelte) when invoking an
-/// embedded language's printer; defaults to a standalone, column-0,
-/// no-suffix, no-base-offset layout.
+/// Embedding state for a render, threaded into the renderer alongside the doc
+/// tree. This is per-input *state*, not configuration: the host language (e.g.
+/// tsv_svelte) constructs it when invoking an embedded language's printer.
+/// Defaults to a standalone, column-0, no-suffix, no-base-offset layout.
 #[derive(Debug, Clone, Copy)]
 pub struct EmbedContext {
     /// Base indent offset for width calculations.

--- a/crates/tsv_lang/src/lib.rs
+++ b/crates/tsv_lang/src/lib.rs
@@ -5,7 +5,7 @@
 //! - `LocationTracker` - line/column information
 //! - `ParseError` - error types and result aliases
 //! - `OutputBuffer` - shared printer output utilities
-//! - `PrintConfig` - shared printer configuration
+//! - `config` - hardcoded formatter settings (`PRINT_WIDTH` / `TAB_WIDTH` / `INDENT`)
 //! - `Comment` - shared comment type
 //! - `doc` - document builder primitives for prettier-compatible formatting
 //! - `escapes` - escape sequence utilities for printers
@@ -34,7 +34,7 @@ pub use comment::{
     has_line_comments_in_range, has_multiline_block_comments_in_range, leading_comments,
     trailing_comments,
 };
-pub use config::{EmbedContext, INDENT, LayoutMode, PRINT_WIDTH, PrintConfig, TAB_WIDTH};
+pub use config::{EmbedContext, INDENT, LayoutMode, PRINT_WIDTH, TAB_WIDTH};
 pub use error::{ErrorContext, ParseError, Result};
 pub use interner::{InfallibleResolve, SharedInterner, SymbolResolver, SymbolToU32};
 pub use json::estimated_json_capacity;

--- a/crates/tsv_lang/src/printing.rs
+++ b/crates/tsv_lang/src/printing.rs
@@ -8,22 +8,6 @@ use crate::escapes::swap_quote_escaping;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
 
-/// Options for string literal formatting
-#[derive(Debug, Clone, Copy)]
-pub struct StringFormatOptions {
-    /// Prefer single quotes over double quotes (when counts are equal)
-    /// Default: true (matches prettier-plugin-svelte)
-    pub prefer_single_quotes: bool,
-}
-
-impl Default for StringFormatOptions {
-    fn default() -> Self {
-        Self {
-            prefer_single_quotes: true,
-        }
-    }
-}
-
 /// Format a string literal with optimal quote selection
 ///
 /// Takes raw string content (with escape sequences preserved) and formats it
@@ -41,7 +25,6 @@ impl Default for StringFormatOptions {
 ///
 /// * `raw_content` - String content without surrounding quotes (with escapes preserved)
 /// * `original_quote` - The quote character in the original source (`'` or `"`)
-/// * `options` - Formatting options (quote preference)
 ///
 /// # Returns
 ///
@@ -50,29 +33,25 @@ impl Default for StringFormatOptions {
 /// # Examples
 ///
 /// ```
-/// use tsv_lang::printing::{format_string_literal, StringFormatOptions};
+/// use tsv_lang::printing::format_string_literal;
 ///
 /// // String with no quotes - uses preferred quote (single)
-/// let result = format_string_literal("hello", '"', StringFormatOptions::default());
+/// let result = format_string_literal("hello", '"');
 /// assert_eq!(result, "'hello'");
 ///
 /// // String with single quotes - switches to double to avoid escaping
-/// let result = format_string_literal("it's nice", '\'', StringFormatOptions::default());
+/// let result = format_string_literal("it's nice", '\'');
 /// assert_eq!(result, r#""it's nice""#);
 ///
 /// // String with double quotes - stays single to minimize escaping
-/// let result = format_string_literal(r#"say "hi""#, '\'', StringFormatOptions::default());
+/// let result = format_string_literal(r#"say "hi""#, '\'');
 /// assert_eq!(result, r#"'say "hi"'"#);
 ///
 /// // Preserves escape sequences
-/// let result = format_string_literal(r"\u0041\n", '"', StringFormatOptions::default());
+/// let result = format_string_literal(r"\u0041\n", '"');
 /// assert_eq!(result, r"'\u0041\n'");
 /// ```
-pub fn format_string_literal(
-    raw_content: &str,
-    original_quote: char,
-    options: StringFormatOptions,
-) -> String {
+pub fn format_string_literal(raw_content: &str, original_quote: char) -> String {
     // Count quotes in the raw content (with escapes) to make the best choice
     let single_count = raw_content.matches('\'').count();
     let double_count = raw_content.matches('"').count();
@@ -83,12 +62,9 @@ pub fn format_string_literal(
     } else if single_count < double_count {
         '\''
     } else {
-        // Tie-breaker: use preference (default: single quotes)
-        if options.prefer_single_quotes {
-            '\''
-        } else {
-            '"'
-        }
+        // Tie-breaker: prefer single quotes (hardcoded — matches
+        // prettier-plugin-svelte; tsv is non-configurable, not an option).
+        '\''
     };
 
     // Swap quote escaping if needed, or use raw content as-is
@@ -745,24 +721,24 @@ mod tests {
 
     #[test]
     fn test_no_quotes_uses_preferred() {
-        let result = format_string_literal("hello", '"', StringFormatOptions::default());
+        let result = format_string_literal("hello", '"');
         assert_eq!(result, "'hello'");
     }
 
     #[test]
     fn test_switches_to_minimize_escaping() {
         // Has single quote - switch to double
-        let result = format_string_literal("it's", '\'', StringFormatOptions::default());
+        let result = format_string_literal("it's", '\'');
         assert_eq!(result, r#""it's""#);
 
         // Has double quote - stay single
-        let result = format_string_literal(r#"say "hi""#, '\'', StringFormatOptions::default());
+        let result = format_string_literal(r#"say "hi""#, '\'');
         assert_eq!(result, r#"'say "hi"'"#);
     }
 
     #[test]
     fn test_preserves_escape_sequences() {
-        let result = format_string_literal(r"\u0041\n\t", '"', StringFormatOptions::default());
+        let result = format_string_literal(r"\u0041\n\t", '"');
         assert_eq!(result, r"'\u0041\n\t'");
     }
 
@@ -770,23 +746,14 @@ mod tests {
     fn test_swaps_quote_escaping_when_changing_quotes() {
         // Original: "it\'s" with single quote
         // After: "it's" with double quote (unescape the single quote)
-        let result = format_string_literal(r"it\'s", '\'', StringFormatOptions::default());
+        let result = format_string_literal(r"it\'s", '\'');
         assert_eq!(result, r#""it's""#);
-    }
-
-    #[test]
-    fn test_prefer_double_quotes_option() {
-        let options = StringFormatOptions {
-            prefer_single_quotes: false,
-        };
-        let result = format_string_literal("hello", '\'', options);
-        assert_eq!(result, r#""hello""#);
     }
 
     #[test]
     fn test_already_optimal_quote() {
         // Already using single quotes, no change needed
-        let result = format_string_literal("hello", '\'', StringFormatOptions::default());
+        let result = format_string_literal("hello", '\'');
         assert_eq!(result, "'hello'");
     }
 
@@ -796,7 +763,7 @@ mod tests {
         // Original (with double quotes): "a "b" "c" "d" e's"
         // After switching to single: 'a "b" "c" "d" e\'s' (single quote gets escaped)
         let content = r#"a "b" "c" "d" e's"#;
-        let result = format_string_literal(content, '"', StringFormatOptions::default());
+        let result = format_string_literal(content, '"');
         // Expected: single quote wrapper, double quotes unescaped, single quote escaped
         assert_eq!(result, "'a \"b\" \"c\" \"d\" e\\'s'");
     }

--- a/crates/tsv_svelte/CLAUDE.md
+++ b/crates/tsv_svelte/CLAUDE.md
@@ -11,7 +11,7 @@ Depends on:
 - `tsv_css` — embedded CSS: `<style>` blocks
 - `tsv_html` — element classification (block / inline / void), whitespace rules
 
-Sources of truth: Svelte's compiler for AST shape, Prettier (`svelte` plugin) for formatting. Scope is `.svelte` files only — `.svelte.ts` rune modules are pure TypeScript and go through `tsv_ts` with `TsConfig::svelte()` (this crate does not handle them).
+Sources of truth: Svelte's compiler for AST shape, Prettier (`svelte` plugin) for formatting. Scope is `.svelte` files only — `.svelte.ts` rune modules are pure TypeScript and go through `tsv_ts` (this crate does not handle them).
 
 See [../../CLAUDE.md §Project Structure](../../CLAUDE.md#project-structure) for the standard crate layout (`ast/` / `lexer/` / `parser/` / `printer/`) and project-wide conventions.
 

--- a/crates/tsv_svelte/src/printer/attributes.rs
+++ b/crates/tsv_svelte/src/printer/attributes.rs
@@ -227,7 +227,7 @@ impl<'a> Printer<'a> {
 
     /// Build a Doc for an expression tag inside an attribute value.
     fn build_attribute_expression_doc(&self, expr_tag: &internal::ExpressionTag) -> DocId {
-        self.build_expression_tag_doc_with_config(expr_tag, tsv_lang::PrintConfig::default())
+        self.build_expression_tag_doc(expr_tag)
     }
 
     /// Build a Doc for attribute text content, handling newlines as literallines.
@@ -433,7 +433,6 @@ impl<'a> Printer<'a> {
     fn build_expression_doc_for_attribute(
         &self,
         expr: &tsv_ts::ast::internal::Expression,
-        config: tsv_lang::PrintConfig,
     ) -> DocId {
         let d = self.d();
         let embedded = tsv_lang::EmbedContext {
@@ -448,11 +447,10 @@ impl<'a> Printer<'a> {
                 expr,
                 self.source,
                 Rc::clone(&self.interner),
-                &config,
                 &embedded,
                 self.comments,
                 &self.line_breaks,
-                tsv_ts::TsConfig::svelte(),
+                tsv_ts::TsContext::Svelte,
             );
             return d.parens(inner);
         }
@@ -462,11 +460,10 @@ impl<'a> Printer<'a> {
             expr,
             self.source,
             Rc::clone(&self.interner),
-            &config,
             &embedded,
             self.comments,
             &self.line_breaks,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         )
     }
 
@@ -551,7 +548,7 @@ impl<'a> Printer<'a> {
             }
         }
 
-        let expr_doc = self.build_expression_doc_for_attribute(expr, self.config);
+        let expr_doc = self.build_expression_doc_for_attribute(expr);
 
         // Collect trailing comments
         let mut trailing_comments = Vec::new();
@@ -666,11 +663,6 @@ impl<'a> Printer<'a> {
     }
 
     /// Build a Doc for an expression tag: `{expr}`
-    pub(super) fn build_expression_tag_doc(&self, tag: &internal::ExpressionTag) -> DocId {
-        self.build_expression_tag_doc_with_config(tag, self.config)
-    }
-
-    /// Build a Doc for an expression tag with a specific config
     ///
     /// For binary expressions, uses continuation indent so wrapped lines are indented
     /// relative to the opening `{`:
@@ -679,11 +671,7 @@ impl<'a> Printer<'a> {
     ///   condB &&
     ///   condC}
     /// ```
-    fn build_expression_tag_doc_with_config(
-        &self,
-        tag: &internal::ExpressionTag,
-        config: tsv_lang::PrintConfig,
-    ) -> DocId {
+    pub(super) fn build_expression_tag_doc(&self, tag: &internal::ExpressionTag) -> DocId {
         let d = self.d();
         let mut parts = vec![d.text("{")];
 
@@ -695,7 +683,7 @@ impl<'a> Printer<'a> {
             }
         }
 
-        parts.push(self.build_expression_doc_for_attribute(&tag.expression, config));
+        parts.push(self.build_expression_doc_for_attribute(&tag.expression));
 
         // Add trailing comments (block comments only in expression tags)
         let expr_end = tag.expression.span().end;

--- a/crates/tsv_svelte/src/printer/attributes.rs
+++ b/crates/tsv_svelte/src/printer/attributes.rs
@@ -428,7 +428,7 @@ impl<'a> Printer<'a> {
 
     /// Build expression doc for attribute context (embedded expression).
     ///
-    /// Sets `is_embedded_expression = true` so binary expressions use ContinuationIndent style.
+    /// Sets `LayoutMode::Embedded` so binary expressions use ContinuationIndent style.
     /// Assignment expressions get wrapped in parens: `prop={(a = b)}`.
     fn build_expression_doc_for_attribute(
         &self,

--- a/crates/tsv_svelte/src/printer/mod.rs
+++ b/crates/tsv_svelte/src/printer/mod.rs
@@ -31,7 +31,7 @@ use self::text::TextAnalysis;
 use crate::ast::internal::{self, FragmentNode};
 use std::rc::Rc;
 use tsv_lang::doc::arena::{DocArena, DocId};
-use tsv_lang::{Comment, EmbedContext, OutputBuffer, PrintConfig, SharedInterner, SymbolResolver};
+use tsv_lang::{Comment, EmbedContext, OutputBuffer, SharedInterner, SymbolResolver};
 
 /// Pending whitespace state - buffers whitespace decisions until next node is known
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -144,8 +144,6 @@ pub(crate) struct Printer<'a> {
     buffer: OutputBuffer,
     /// Current indentation level
     pub(crate) indent_level: usize,
-    /// Print configuration
-    config: PrintConfig,
     /// Embedding context (layout mode, offsets)
     embed: EmbedContext,
     /// Arena allocator for doc nodes
@@ -161,30 +159,22 @@ pub(crate) struct Printer<'a> {
 }
 
 impl<'a> Printer<'a> {
-    /// Create a new printer with the given source, interner, comments, and default config
+    /// Create a new printer with the given source, interner, and comments (standalone layout).
     pub(crate) fn new(source: &'a str, interner: SharedInterner, comments: &'a [Comment]) -> Self {
-        Self::with_config(
-            source,
-            interner,
-            comments,
-            PrintConfig::default(),
-            EmbedContext::default(),
-        )
+        Self::with_embed(source, interner, comments, EmbedContext::default())
     }
 
-    /// Create a new printer with the given source, interner, comments, config, and embed context
-    pub(crate) fn with_config(
+    /// Create a new printer with the given source, interner, comments, and embed context.
+    pub(crate) fn with_embed(
         source: &'a str,
         interner: SharedInterner,
         comments: &'a [Comment],
-        config: PrintConfig,
         embed: EmbedContext,
     ) -> Self {
         let line_breaks = tsv_lang::printing::build_line_breaks(source);
         Self {
             buffer: OutputBuffer::with_capacity(source.len()),
             indent_level: 0,
-            config,
             embed,
             arena: DocArena::for_source(source),
             source,
@@ -257,19 +247,19 @@ impl<'a> Printer<'a> {
 impl<'a> Printer<'a> {
     /// Build a DocId for a TS expression (with comments) in our arena.
     ///
-    /// Uses the standard parameters: self.comments, self.config, self.line_breaks.
-    /// For calls that need custom config or empty comments, use the tsv_ts functions directly.
+    /// Uses the standard parameters: self.comments, self.embed, self.line_breaks.
+    /// For calls that need a custom embed context or empty comments, use the
+    /// tsv_ts functions directly.
     pub(crate) fn build_ts_expression_doc(&self, expr: &tsv_ts::Expression) -> DocId {
         tsv_ts::build_expression_doc_with_comments(
             self.d(),
             expr,
             self.source,
             Rc::clone(&self.interner),
-            &self.config,
             &self.embed,
             self.comments,
             &self.line_breaks,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         )
     }
 
@@ -283,11 +273,10 @@ impl<'a> Printer<'a> {
             expr,
             self.source,
             Rc::clone(&self.interner),
-            &self.config,
             &self.embed,
             &[],
             &self.line_breaks,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         )
     }
 
@@ -301,9 +290,8 @@ impl<'a> Printer<'a> {
             Rc::clone(&self.interner),
             &[],
             &self.line_breaks,
-            PrintConfig::default(),
             EmbedContext::default(),
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         )
     }
 }

--- a/crates/tsv_svelte/src/printer/nodes/helpers.rs
+++ b/crates/tsv_svelte/src/printer/nodes/helpers.rs
@@ -116,7 +116,6 @@ impl<'a> Printer<'a> {
         let first_line_offset = self.buffer.current_column(tsv_lang::TAB_WIDTH);
         // Pass current indent level so wrapped lines get proper indentation
         let base_indent_offset = self.indent_level;
-        let config = tsv_lang::PrintConfig::default();
         let embed = tsv_lang::EmbedContext {
             first_line_offset,
             suffix_width,
@@ -131,9 +130,8 @@ impl<'a> Printer<'a> {
             Rc::clone(&self.interner),
             self.comments,
             &self.line_breaks,
-            config,
             embed,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         );
         self.write(&formatted);
 
@@ -409,11 +407,10 @@ impl<'a> Printer<'a> {
             expr,
             self.source,
             Rc::clone(&self.interner),
-            &self.config,
             &embed,
             self.comments,
             &self.line_breaks,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         );
 
         // Build docs for trailing comments (between expression end and span_end)
@@ -490,11 +487,10 @@ impl<'a> Printer<'a> {
                 expr,
                 self.source,
                 Rc::clone(&self.interner),
-                &self.config,
                 &embed,
                 self.comments,
                 &self.line_breaks,
-                tsv_ts::TsConfig::svelte(),
+                tsv_ts::TsContext::Svelte,
             );
             d.parens(inner)
         } else {
@@ -503,11 +499,10 @@ impl<'a> Printer<'a> {
                 expr,
                 self.source,
                 Rc::clone(&self.interner),
-                &self.config,
                 &embed,
                 self.comments,
                 &self.line_breaks,
-                tsv_ts::TsConfig::svelte(),
+                tsv_ts::TsContext::Svelte,
             )
         };
 

--- a/crates/tsv_svelte/src/printer/nodes/helpers.rs
+++ b/crates/tsv_svelte/src/printer/nodes/helpers.rs
@@ -368,7 +368,7 @@ impl<'a> Printer<'a> {
     /// - Trailing comments: between expr.span().end and span_end
     ///
     /// Builds the expression doc directly in the shared arena using
-    /// `build_expression_doc_with_comments` with `is_embedded_expression = true`
+    /// `build_expression_doc_with_comments` with `LayoutMode::Embedded`
     /// so binary chains use ContinuationIndent style. The surrounding Svelte doc tree
     /// (e.g., the closing `}`) provides natural lookahead for fits checks — no
     /// `suffix_width` estimation needed.
@@ -441,7 +441,7 @@ impl<'a> Printer<'a> {
     ///
     /// - **Multiline context** (`in_multiline_context=true`): The condition is on its own line.
     ///   No `remove_lines()` is applied, allowing long chains to wrap naturally.
-    ///   Uses `is_embedded_expression` for proper continuation indent on wrapped binary expressions.
+    ///   Uses `LayoutMode::Embedded` for proper continuation indent on wrapped binary expressions.
     ///
     /// # Parameters
     /// - `opening_offset` - Characters before the expression (e.g., 5 for `{#if `). Used to

--- a/crates/tsv_svelte/src/printer/nodes/tags_doc.rs
+++ b/crates/tsv_svelte/src/printer/nodes/tags_doc.rs
@@ -42,7 +42,7 @@ impl<'a> Printer<'a> {
     pub(crate) fn build_const_tag_doc(&self, tag: &internal::ConstTag) -> DocId {
         let d = self.d();
         let id_doc = self.build_ts_expression_doc_no_comments(&tag.id);
-        // Build init with is_embedded_expression=false so binary chains use Grouped style
+        // Build init with LayoutMode::Standalone so binary chains use Grouped style
         // (not ContinuationIndent). The assignment layout handles indentation —
         // ContinuationIndent would double-indent continuation lines.
         let init_doc = self.build_const_init_doc(

--- a/crates/tsv_svelte/src/printer/nodes/tags_doc.rs
+++ b/crates/tsv_svelte/src/printer/nodes/tags_doc.rs
@@ -145,11 +145,10 @@ impl<'a> Printer<'a> {
             expr,
             self.source,
             Rc::clone(&self.interner),
-            &self.config,
             &embed,
             self.comments,
             &self.line_breaks,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         );
 
         let trailing_docs: Vec<DocId> =

--- a/crates/tsv_svelte/src/printer/script_style.rs
+++ b/crates/tsv_svelte/src/printer/script_style.rs
@@ -41,7 +41,7 @@ impl<'a> Printer<'a> {
             &script.content,
             self.source(),
             embed,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         );
 
         // Render with indent
@@ -186,13 +186,12 @@ impl<'a> Printer<'a> {
             // Pass the entire source to CSS printer (CSS node spans are absolute)
             // The CSS printer will use the spans to detect blank lines correctly
             // Use base_indent_offset=1 to account for the Svelte wrapper indent
-            let config = tsv_lang::PrintConfig::default();
             let embed = tsv_lang::EmbedContext {
                 base_indent_offset: 1,
                 ..tsv_lang::EmbedContext::default()
             };
             let formatted_css =
-                tsv_css::format_with_config(&style.css_stylesheet, self.source(), config, embed);
+                tsv_css::format_embedded(&style.css_stylesheet, self.source(), embed);
 
             // Indent each line - trim trailing newlines first to avoid extra blank lines
             // Note: CSS formatter adds trailing newline, we need to remove it before line processing

--- a/crates/tsv_svelte/src/printer/tags.rs
+++ b/crates/tsv_svelte/src/printer/tags.rs
@@ -57,9 +57,8 @@ impl<'a> Printer<'a> {
             Rc::clone(&self.interner),
             self.comments,
             &self.line_breaks,
-            tsv_lang::PrintConfig::default(),
             embed,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         );
         self.write(&formatted_id);
         self.write(" = ");
@@ -76,9 +75,8 @@ impl<'a> Printer<'a> {
             Rc::clone(&self.interner),
             self.comments,
             &self.line_breaks,
-            tsv_lang::PrintConfig::default(),
             embed,
-            tsv_ts::TsConfig::svelte(),
+            tsv_ts::TsContext::Svelte,
         );
         self.write(&formatted_init);
 

--- a/crates/tsv_ts/CLAUDE.md
+++ b/crates/tsv_ts/CLAUDE.md
@@ -15,8 +15,8 @@ Standard `ast/` (internal + public + convert), `lexer/`, `parser/`, `printer/` l
 **Standalone** (`.ts` files, top-level callers):
 
 - `parse(source) -> Result<Program>`
-- `format(program, source) -> String` — uses `TsConfig::default()`
-- `format_with_config(program, source, ts_config) -> String`
+- `format(program, source) -> String` — uses `TsContext::Standalone`
+- `format_with_context(program, source, ts_context) -> String`
 - `convert_ast(program, source) -> public::Program` / `convert_ast_json(...) -> serde_json::Value` / `convert_ast_json_string(...) -> String` (all gated on `convert` feature). The string variant is the compact-wire hot path (FFI/WASM/CLI non-pretty): it serializes the typed public AST directly when eligible, never materializing the intermediate `Value` (per-language eligibility matrix: [docs/architecture.md §Closed Scope, Open Convention](../../docs/architecture.md#closed-scope-open-convention)). The typed offset-translation walk (`ast/convert/translate_typed.rs`) is the typed mirror of the `Value` walk in `ast/convert/mod.rs` — the two must stay byte-identical, gated by the fixture suite's string-path identity check and typed-walk parity probes (synthesized multibyte variants plus extracted `<script>` contents, so every fixture's AST shapes are covered) and `json_profile`'s corpus comparison. Output is byte-identical to serializing `convert_ast_json`'s `Value`.
 
 **Embedding** (used by `tsv_svelte` — shares interner, indent, comment buffers with the host document):
@@ -28,7 +28,7 @@ Standard `ast/` (internal + public + convert), `lexer/`, `parser/`, `printer/` l
 
 ## Distinctives
 
-- **`TsConfig`** ([`config.rs`](src/config.rs)) is the per-language knob and the type unique to this crate. Default is pure-TS (`arrow_type_param_trailing_comma: false`). `TsConfig::svelte()` enables `<T,>` trailing-comma disambiguation — `tsv_svelte` passes this when formatting embedded TS so `<T>` isn't ambiguous with template syntax. Pure `.ts` and `.svelte.ts` files use the default.
+- **`TsContext`** ([`config.rs`](src/config.rs)) is the per-language context unique to this crate — not user configuration (tsv is non-configurable), but the standalone-vs-Svelte distinction derived from the file kind. Default is `TsContext::Standalone` (pure TS). `TsContext::Svelte` enables `<T,>` trailing-comma disambiguation — `tsv_svelte` passes it when formatting embedded TS so `<T>` isn't ambiguous with template syntax. Pure `.ts` and `.svelte.ts` files use `Standalone`.
 - **`Schema`** in [`ast/convert/mod.rs`](src/ast/convert/mod.rs) selects the public-AST shape. `convert_ast()` always uses `Schema::Acorn`; callers needing Svelte's non-`lang="ts"` `<script>` shape (omit `importKind`/`exportKind="value"`, always emit `attributes`) invoke `ast::convert::convert_program(..., Schema::SvelteScript)` directly. Tracked alongside the hand-maintained `tsv_ast.d.ts` — see [../tsv_wasm/CLAUDE.md §TS type maintenance](../tsv_wasm/CLAUDE.md#ts-type-maintenance).
 - **`lexer/escapes.rs`** owns ECMAScript string/template escape decoding (acorn parity). `tsv_lang::escapes` only handles quote swapping at print time; full decoding lives here.
 - **Strict mode only** — no `with`, no legacy octals, no duplicate parameters. See [../../CLAUDE.md §Strict Mode Only](../../CLAUDE.md#strict-mode-only).

--- a/crates/tsv_ts/src/config.rs
+++ b/crates/tsv_ts/src/config.rs
@@ -1,32 +1,36 @@
-//! TypeScript-specific printer configuration.
+//! TypeScript formatting context.
 //!
-//! Concerns that only apply when formatting TypeScript live here, separate
-//! from the language-agnostic [`tsv_lang::PrintConfig`].
+//! tsv is non-configurable — there are no user-facing TypeScript options. This
+//! type is not configuration: it records whether the TypeScript being formatted
+//! is standalone or embedded in a Svelte file, a distinction derived from the
+//! file kind that selects context-dependent formatting required for Prettier
+//! parity. It is the only such knob today (arrow-type-param disambiguation), so
+//! it stays separate from the language-agnostic [`tsv_lang::EmbedContext`].
 
-/// TypeScript-only formatter configuration.
+/// Whether TypeScript is being formatted on its own or embedded in a Svelte
+/// file.
 ///
-/// Holds knobs whose only meaning is in a TS context, kept out of the
-/// foundation crate so it doesn't carry language-specific concerns.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct TsConfig {
-    /// Whether to add a trailing comma for arrow function type params for
-    /// disambiguation. Default: false (pure-TS behavior).
-    ///
-    /// When true, single type params in arrow functions get a trailing comma:
-    /// `<T,>` instead of `<T>`. Set this when formatting TS embedded in a
-    /// Svelte template, where `<T>` could be parsed as an HTML-style tag.
-    /// Pure `.ts` and `.svelte.ts` files use the default `false`.
-    pub arrow_type_param_trailing_comma: bool,
+/// Not user configuration — the host picks the variant from the file kind. The
+/// only behavior it currently gates is arrow-function type-param trailing-comma
+/// disambiguation (`<T>` vs `<T,>`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TsContext {
+    /// A standalone `.ts` / `.svelte.ts` file. Single arrow type params stay
+    /// bare (`<T>`), matching Prettier's pure-TypeScript output.
+    #[default]
+    Standalone,
+    /// TypeScript embedded in a Svelte file (`<script>` blocks, template
+    /// `{expr}` slots). Single arrow type params get a trailing comma (`<T,>`)
+    /// so `<T>` isn't ambiguous with Svelte's template/element syntax. Used by
+    /// `tsv_svelte` when formatting embedded TypeScript.
+    Svelte,
 }
 
-impl TsConfig {
-    /// Config for TypeScript embedded in a Svelte file. Enables
-    /// arrow-type-param trailing commas so `<T>` isn't ambiguous with template
-    /// syntax. Used by `tsv_svelte` when formatting `<script>` blocks and
-    /// template expressions.
-    pub fn svelte() -> Self {
-        Self {
-            arrow_type_param_trailing_comma: true,
-        }
+impl TsContext {
+    /// Whether a single arrow-function type param needs the `<T,>` trailing
+    /// comma for Svelte disambiguation. True only for [`TsContext::Svelte`].
+    #[inline]
+    pub(crate) fn arrow_type_param_trailing_comma(self) -> bool {
+        matches!(self, TsContext::Svelte)
     }
 }

--- a/crates/tsv_ts/src/lib.rs
+++ b/crates/tsv_ts/src/lib.rs
@@ -24,12 +24,12 @@ mod lexer;
 mod parser;
 mod printer;
 
-pub use config::TsConfig;
+pub use config::TsContext;
 
 use std::rc::Rc;
 
+use tsv_lang::EmbedContext;
 use tsv_lang::doc::arena::{DocArena, DocId};
-use tsv_lang::{EmbedContext, PrintConfig};
 pub use tsv_lang::{ParseError, Result, SharedInterner};
 
 /// Build a fully-configured printer borrowing the given arena/source/state.
@@ -43,19 +43,17 @@ fn make_printer<'a>(
     interner: SharedInterner,
     comments: &'a [ast::Comment],
     line_breaks: &'a [u32],
-    config: PrintConfig,
     embed: EmbedContext,
-    ts_config: TsConfig,
+    ts_context: TsContext,
 ) -> printer::Printer<'a> {
-    printer::Printer::with_config(
+    printer::Printer::with_context(
         arena,
         interner,
         source,
         comments,
         line_breaks,
-        config,
         embed,
-        ts_config,
+        ts_context,
     )
 }
 
@@ -98,15 +96,15 @@ pub fn parse(source: &str) -> Result<Program> {
 /// assert_eq!(formatted, "const x = 42;\n");
 /// ```
 pub fn format(program: &Program, source: &str) -> String {
-    format_with_config(program, source, TsConfig::default())
+    format_with_context(program, source, TsContext::Standalone)
 }
 
-/// Format an internal AST back to source code with custom TypeScript-specific
-/// configuration (e.g., trailing-comma behavior on arrow type params).
+/// Format an internal AST back to source code in a given [`TsContext`].
 ///
-/// Pure-TS callers (CLI/debug) pass `TsConfig { arrow_type_param_trailing_comma: false, .. }`
-/// to suppress the Svelte-template disambiguation.
-pub fn format_with_config(program: &Program, source: &str, ts_config: TsConfig) -> String {
+/// Standalone `.ts` callers use [`format`] ([`TsContext::Standalone`]);
+/// `tsv_svelte` passes [`TsContext::Svelte`] when formatting embedded
+/// TypeScript so `<T>` arrow type params get the disambiguating trailing comma.
+pub fn format_with_context(program: &Program, source: &str, ts_context: TsContext) -> String {
     let arena = DocArena::for_source(source);
     let mut printer = make_printer(
         &arena,
@@ -114,9 +112,8 @@ pub fn format_with_config(program: &Program, source: &str, ts_config: TsConfig) 
         Rc::clone(&program.interner),
         &program.comments,
         &program.line_breaks,
-        PrintConfig::default(),
         EmbedContext::default(),
-        ts_config,
+        ts_context,
     );
     printer.print_program(program);
     printer.into_string()
@@ -243,9 +240,8 @@ pub fn format_expression(
     interner: SharedInterner,
     comments: &[ast::Comment],
     line_breaks: &[u32],
-    config: PrintConfig,
     embed: EmbedContext,
-    ts_config: TsConfig,
+    ts_context: TsContext,
 ) -> String {
     let arena = DocArena::for_source(source);
     let mut printer = make_printer(
@@ -254,9 +250,8 @@ pub fn format_expression(
         interner,
         comments,
         line_breaks,
-        config,
         embed,
-        ts_config,
+        ts_context,
     );
     printer.set_indent_level(embed.base_indent_offset);
     printer.print_expression(expression);
@@ -362,11 +357,10 @@ pub fn build_expression_doc_with_comments(
     expression: &Expression,
     source: &str,
     interner: SharedInterner,
-    config: &PrintConfig,
     embed: &EmbedContext,
     comments: &[ast::Comment],
     line_breaks: &[u32],
-    ts_config: TsConfig,
+    ts_context: TsContext,
 ) -> DocId {
     let printer = make_printer(
         arena,
@@ -374,9 +368,8 @@ pub fn build_expression_doc_with_comments(
         interner,
         comments,
         line_breaks,
-        *config,
         *embed,
-        ts_config,
+        ts_context,
     );
     printer.build_expression_doc(expression)
 }
@@ -390,7 +383,7 @@ pub fn build_program_doc(
     program: &Program,
     source: &str,
     embed: EmbedContext,
-    ts_config: TsConfig,
+    ts_context: TsContext,
 ) -> DocId {
     let printer = make_printer(
         arena,
@@ -398,9 +391,8 @@ pub fn build_program_doc(
         Rc::clone(&program.interner),
         &program.comments,
         &program.line_breaks,
-        PrintConfig::default(),
         embed,
-        ts_config,
+        ts_context,
     );
     printer.build_program_doc(program)
 }

--- a/crates/tsv_ts/src/printer/expressions/functions.rs
+++ b/crates/tsv_ts/src/printer/expressions/functions.rs
@@ -747,7 +747,7 @@ impl<'a> Printer<'a> {
 
         // Svelte disambiguation: single param without constraint needs trailing comma
         // in Svelte files to avoid confusion with template syntax like `<Component>`.
-        // In pure .ts files (arrow_type_param_trailing_comma=false), no trailing comma needed.
+        // In pure .ts files (`TsContext::Standalone`), no trailing comma needed.
         let needs_trailing_comma = self.ts_context.arrow_type_param_trailing_comma()
             && decl.params.len() == 1
             && decl.params[0].constraint.is_none();

--- a/crates/tsv_ts/src/printer/expressions/functions.rs
+++ b/crates/tsv_ts/src/printer/expressions/functions.rs
@@ -748,7 +748,7 @@ impl<'a> Printer<'a> {
         // Svelte disambiguation: single param without constraint needs trailing comma
         // in Svelte files to avoid confusion with template syntax like `<Component>`.
         // In pure .ts files (arrow_type_param_trailing_comma=false), no trailing comma needed.
-        let needs_trailing_comma = self.ts_config.arrow_type_param_trailing_comma
+        let needs_trailing_comma = self.ts_context.arrow_type_param_trailing_comma()
             && decl.params.len() == 1
             && decl.params[0].constraint.is_none();
         let inner_parts = if needs_trailing_comma {

--- a/crates/tsv_ts/src/printer/expressions/literals.rs
+++ b/crates/tsv_ts/src/printer/expressions/literals.rs
@@ -13,7 +13,7 @@ use crate::printer::Printer;
 use crate::printer::analysis;
 use tsv_lang::SymbolToU32;
 use tsv_lang::doc::arena::DocId;
-use tsv_lang::printing::{StringFormatOptions, format_string_literal};
+use tsv_lang::printing::format_string_literal;
 
 /// Format a string literal from the AST to its printed form.
 ///
@@ -28,7 +28,7 @@ pub(crate) fn format_string_literal_from_ast(literal: &internal::Literal, source
         _ => unreachable!("format_string_literal_from_ast called on non-string literal"),
     };
 
-    format_string_literal(raw_content, quote, StringFormatOptions::default())
+    format_string_literal(raw_content, quote)
 }
 
 /// Format a directive prologue string (`'use strict'`) for printing.
@@ -47,7 +47,7 @@ pub(crate) fn format_directive(raw: &str) -> String {
     if content.contains('\'') || content.contains('"') {
         raw.to_string()
     } else {
-        // Preferred quote is single (matches `StringFormatOptions::default`).
+        // Preferred quote is single (matches `format_string_literal`'s hardcoded tie-breaker).
         format!("'{content}'")
     }
 }

--- a/crates/tsv_ts/src/printer/expressions/operators.rs
+++ b/crates/tsv_ts/src/printer/expressions/operators.rs
@@ -849,10 +849,10 @@ impl<'a> Printer<'a> {
         // This gives: `(first &&\n\t\tsecond)` not `(first &&\n\tsecond)`
         //
         // Context-dependent behavior:
-        // - Script contexts (is_embedded_expression = false): Use group with parens INSIDE
+        // - Script contexts (LayoutMode::Standalone): Use group with parens INSIDE
         //   so the fit calculation includes `)`. This ensures `(A + B) *` at 101 chars
         //   breaks inside the parens, not just at `*`.
-        // - Embedded expression contexts (is_embedded_expression = true): Use the grouped
+        // - Embedded expression contexts (LayoutMode::Embedded): Use the grouped
         //   approach from build_binary_chain_doc_with_continuation_indent, which keeps
         //   short 2-operand binaries flat (Prettier's behavior for template expressions).
         if needs_parens(operand, ctx) {

--- a/crates/tsv_ts/src/printer/mod.rs
+++ b/crates/tsv_ts/src/printer/mod.rs
@@ -58,10 +58,10 @@ pub(crate) use needs_parens::{ParenContext, needs_parens};
 pub(crate) use types::{should_hug_union_type, unwrap_parenthesized};
 
 use crate::ast::internal;
-use crate::config::TsConfig;
+use crate::config::TsContext;
 use std::cell::Cell;
 use tsv_lang::{
-    EmbedContext, OutputBuffer, PrintConfig, SharedInterner, SymbolResolver, comments_in_range,
+    EmbedContext, OutputBuffer, SharedInterner, SymbolResolver, comments_in_range,
     doc::{
         self,
         arena::{DocArena, DocId},
@@ -99,14 +99,10 @@ pub struct Printer<'a> {
     buffer: OutputBuffer,
     /// Current indentation level
     pub(crate) indent_level: usize,
-    /// Workspace-wide doc-builder configuration (reserved slot for future
-    /// cross-language toggles — empty today).
-    #[allow(dead_code)]
-    pub(crate) config: PrintConfig,
     /// Embedding context (base indent offset, first-line offset, layout mode, etc.).
     pub(crate) embed: EmbedContext,
-    /// TypeScript-specific configuration (arrow type param trailing comma).
-    pub(crate) ts_config: TsConfig,
+    /// Whether this TypeScript is standalone or embedded in a Svelte file.
+    pub(crate) ts_context: TsContext,
     /// Arena allocator for doc nodes (borrowed from caller or locally owned)
     pub(crate) arena: &'a DocArena,
     /// Shared string interner for resolving symbols
@@ -177,24 +173,22 @@ pub struct Printer<'a> {
 
 impl<'a> Printer<'a> {
     /// Create a new printer with the given arena, interner, source, comments,
-    /// line_breaks, doc-builder config, embedding context, and TS config.
+    /// line_breaks, embedding context, and TS context.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn with_config(
+    pub(crate) fn with_context(
         arena: &'a DocArena,
         interner: SharedInterner,
         source: &'a str,
         comments: &'a [internal::Comment],
         line_breaks: &'a [u32],
-        config: PrintConfig,
         embed: EmbedContext,
-        ts_config: TsConfig,
+        ts_context: TsContext,
     ) -> Self {
         Self {
             buffer: OutputBuffer::with_capacity(source.len()),
             indent_level: 0,
-            config,
             embed,
-            ts_config,
+            ts_context,
             arena,
             interner,
             source,

--- a/crates/tsv_wasm/README_all.md
+++ b/crates/tsv_wasm/README_all.md
@@ -36,7 +36,7 @@ Three formatters (`format_svelte`, `format_typescript`, `format_css`) take a sou
 
 AST types are bundled in `tsv_ast.d.ts` and re-exported from the package — `import type` any node directly.
 
-Formatter settings are hardcoded to match Prettier defaults: `print_width: 100`, `tab_width: 2`, `use_tabs: true`.
+tsv is non-configurable: formatter settings are fixed at Prettier's defaults (`print_width: 100`, `tab_width: 2`, `use_tabs: true`) — no options, like `gofmt` and Black.
 
 ## Status
 

--- a/crates/tsv_wasm/README_format.md
+++ b/crates/tsv_wasm/README_format.md
@@ -41,7 +41,7 @@ const formatted = format_svelte('<script>\nconst   x=1\n</script>');
 
 `init_sync({ module })` is also exported for Workers and custom loading.
 
-Settings are hardcoded to match Prettier defaults: `print_width: 100`, `tab_width: 2`, `use_tabs: true`.
+tsv is non-configurable: settings are fixed at Prettier's defaults (`print_width: 100`, `tab_width: 2`, `use_tabs: true`) — no options, like `gofmt` and Black.
 
 ## Status
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,7 +211,7 @@ Language-agnostic primitives shared across all implementations:
 | `doc`             | **Document builder for prettier-compatible formatting**                                    |
 | `printing`        | Shared formatting utilities (string literals, whitespace)                                  |
 | `OutputBuffer`    | Pre-allocated output string building with column tracking                                  |
-| `config`          | `PRINT_WIDTH` / `TAB_WIDTH` / `INDENT` consts, `PrintConfig`, `EmbedContext`, `LayoutMode` |
+| `config`          | `PRINT_WIDTH` / `TAB_WIDTH` / `INDENT` consts, `EmbedContext`, `LayoutMode` (no runtime config)     |
 | `comment`         | Comment type and lookup utilities (see Comment Handling below)                             |
 | `escapes`         | Escape sequence handling                                                                   |
 | `interner`        | String interner utilities (`SymbolResolver` trait)                                         |

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -20,8 +20,11 @@
  *
  * Flags:
  *   --wetrun         actually mutate: bump, publish, commit, tag, push
- *   --bump <level>   patch | minor | major — how to bump the version.
- *                    Required for a fresh wetrun; only a sentinel retry runs without it.
+ *   --bump <level>   patch | minor | major — how to bump the version. Required,
+ *                    and must match the CHANGELOG `## Unreleased` `<!-- bump:
+ *                    <level> -->` marker (also required). A fresh wetrun needs
+ *                    both, plus a non-empty `## Unreleased` section; a sentinel
+ *                    retry runs without either.
  *   --no-check       skip `deno task check` (faster retries)
  *   --no-git         skip the git commit + tag + push finalization
  *
@@ -57,6 +60,8 @@ if (bump !== null && bump !== 'patch' && bump !== 'minor' && bump !== 'major') {
 	console.error(`FAIL: --bump must be patch, minor, or major (got ${JSON.stringify(bump)})`);
 	Deno.exit(1);
 }
+
+type BumpLevel = 'patch' | 'minor' | 'major';
 
 const SENTINEL_PATH = '.publish-in-progress';
 const CARGO_PATH = 'Cargo.toml';
@@ -222,16 +227,26 @@ if (wetrun) {
 			console.warn(`  WARN: removing stale sentinel (v${initial_sentinel})`);
 			Deno.removeSync(SENTINEL_PATH);
 		}
-		if (bump) {
-			version = bump_version(version_before, bump);
-			const cargo = Deno.readTextFileSync(CARGO_PATH);
-			Deno.writeTextFileSync(CARGO_PATH, cargo.replace(workspace_pkg_re, `$1"${version}"`));
-			console.log(`  Version bumped (${bump}): ${version_before} -> ${version}`);
-		} else {
-			console.error('  FAIL: --bump patch|minor|major is required for a fresh wetrun');
-			console.error('  (only a sentinel retry — resuming a failed wetrun — runs without it)');
+		// A release must ship notes — require a non-empty `## Unreleased`
+		// section before mutating anything (the bump level can live there too).
+		const content = changelog_unreleased_content();
+		if (content === null) {
+			console.error(
+				`  FAIL: no "## Unreleased" section in ${CHANGELOG_PATH} — add release notes before publishing`,
+			);
 			Deno.exit(1);
 		}
+		if (content === '') {
+			console.error(
+				`  FAIL: "## Unreleased" section in ${CHANGELOG_PATH} is empty — add release notes before publishing`,
+			);
+			Deno.exit(1);
+		}
+		const level = resolve_bump(bump as BumpLevel | null, changelog_declared_bump());
+		version = bump_version(version_before, level);
+		const cargo = Deno.readTextFileSync(CARGO_PATH);
+		Deno.writeTextFileSync(CARGO_PATH, cargo.replace(workspace_pkg_re, `$1"${version}"`));
+		console.log(`  Version bumped (${level}): ${version_before} -> ${version}`);
 		// Sentinel immediately after the version write — everything below is
 		// idempotent and re-runs on retry, so any later failure is resumable.
 		Deno.writeTextFileSync(SENTINEL_PATH, version);
@@ -247,25 +262,39 @@ if (wetrun) {
 	version = version_before;
 	console.log(`  Current version: v${version}`);
 	const would_retry = initial_sentinel === version;
+	const declared = changelog_declared_bump();
 	if (would_retry) {
 		// Mirrors wetrun precedence: retry wins over --bump
 		console.log(`  Sentinel found at v${version} — wetrun would retry from it`);
 		if (bump) {
 			console.warn(`  WARN: --bump ${bump} would be ignored — wetrun would resume v${version}`);
 		}
-	} else if (bump) {
-		console.log(`  Wetrun would bump (${bump}) to: v${bump_version(version, bump)}`);
 	} else {
-		console.warn(
-			'  WARN: no --bump given — a fresh wetrun would fail (--bump is required except on sentinel retry)',
-		);
-	}
-	// Warn whenever the eventual wetrun would have nothing to stamp.
-	const stamp_version = bump ? bump_version(version, bump) : version;
-	if (!would_retry && !changelog_has_unreleased() && !changelog_has_version(stamp_version)) {
-		console.warn(
-			`  WARN: no "## Unreleased" section in ${CHANGELOG_PATH} — wetrun would have nothing to stamp`,
-		);
+		// Mirror the wetrun's requirements without exiting — report what it would do.
+		const content = changelog_unreleased_content();
+		if (content === null) {
+			console.warn(`  WARN: no "## Unreleased" section in ${CHANGELOG_PATH} — a fresh wetrun would FAIL`);
+		} else if (content === '') {
+			console.warn(`  WARN: "## Unreleased" section is empty — a fresh wetrun would FAIL`);
+		}
+		if (!bump) {
+			console.warn(
+				'  WARN: no --bump given — a fresh wetrun would FAIL (required, and must match the CHANGELOG marker)',
+			);
+		}
+		if (!declared) {
+			console.warn(
+				`  WARN: no "<!-- bump: <level> -->" marker in ${CHANGELOG_PATH} — a fresh wetrun would FAIL`,
+			);
+		}
+		if (bump && declared && bump !== declared) {
+			console.warn(
+				`  WARN: --bump ${bump} disagrees with CHANGELOG marker <!-- bump: ${declared} --> — a fresh wetrun would FAIL`,
+			);
+		}
+		if (bump && declared && bump === declared) {
+			console.log(`  Wetrun would bump (${bump}) to: v${bump_version(version, bump)}`);
+		}
 	}
 }
 
@@ -348,12 +377,24 @@ for (let i = 0; i < packages.length; i++) {
 		console.log(`  Published ${label}@${version}`);
 	} else {
 		console.log(`  [dry-run] ${label}:`);
-		run(
-			`npm publish --dry-run ${label}`,
-			'npm',
-			['publish', '--dry-run', '--access', 'public'],
-			dir,
-		);
+		const res = capture('npm', ['publish', '--dry-run', '--access', 'public'], dir);
+		// npm prints the tarball notice to stderr — surface it regardless.
+		if (res.stderr) console.log(res.stderr);
+		if (res.success) {
+			console.log(`  PASS: ${label} packs cleanly`);
+		} else if (/cannot publish over|previously published version/i.test(res.stderr)) {
+			// Dry-run never bumps, so it dry-publishes the CURRENT (already-published)
+			// version. The real wetrun bumps first, so this isn't a real failure.
+			const preview = (bump as BumpLevel | null) ?? changelog_declared_bump();
+			const target = preview ? `v${bump_version(version, preview)}` : 'the bumped version';
+			console.log(
+				`  PASS: ${label} packs cleanly (v${version} already published — a real run publishes ${target})`,
+			);
+		} else {
+			if (res.stdout) console.error(res.stdout);
+			console.error(`  FAIL: npm publish --dry-run ${label}`);
+			Deno.exit(1);
+		}
 	}
 }
 
@@ -420,9 +461,11 @@ console.log('');
 function capture(
 	cmd: string,
 	args: string[],
+	cwd?: string,
 ): { success: boolean; stdout: string; stderr: string } {
 	const result = new Deno.Command(cmd, {
 		args,
+		cwd,
 		stdout: 'piped',
 		stderr: 'piped',
 	}).outputSync();
@@ -471,10 +514,10 @@ function stamp_changelog(new_version: string): void {
 		return;
 	}
 	if (/^## Unreleased$/m.test(changelog)) {
-		Deno.writeTextFileSync(
-			CHANGELOG_PATH,
-			changelog.replace(/^## Unreleased$/m, `## ${new_version}`),
-		);
+		const stamped = changelog
+			.replace(/^## Unreleased$/m, `## ${new_version}`)
+			.replace(/^<!-- bump: (?:patch|minor|major) -->\n/m, '');
+		Deno.writeTextFileSync(CHANGELOG_PATH, stamped);
 		console.log(`  Stamped ${CHANGELOG_PATH}: ## Unreleased -> ## ${new_version}`);
 	} else if (version_heading_re(new_version).test(changelog)) {
 		console.log(`  ${CHANGELOG_PATH} already stamped with ## ${new_version}`);
@@ -483,24 +526,68 @@ function stamp_changelog(new_version: string): void {
 	}
 }
 
-function changelog_has_version(target_version: string): boolean {
-	try {
-		return version_heading_re(target_version).test(Deno.readTextFileSync(CHANGELOG_PATH));
-	} catch {
-		return false;
-	}
-}
-
 function version_heading_re(target_version: string): RegExp {
 	return new RegExp(`^## ${target_version.replaceAll('.', '\\.')}$`, 'm');
 }
 
-function changelog_has_unreleased(): boolean {
+/** Body of the `## Unreleased` section (after the heading, up to the next `## `
+ * heading or EOF), or null if there's no such heading. */
+function unreleased_section(changelog: string): string | null {
+	const heading = /^## Unreleased$/m.exec(changelog);
+	if (!heading) return null;
+	const after = changelog.slice(heading.index + heading[0].length);
+	const next = after.search(/^## /m);
+	return next === -1 ? after : after.slice(0, next);
+}
+
+/** Unreleased content with the bump marker + surrounding whitespace stripped.
+ * `''` means an empty section; `null` means no section (or no CHANGELOG). */
+function changelog_unreleased_content(): string | null {
+	let changelog: string;
 	try {
-		return /^## Unreleased$/m.test(Deno.readTextFileSync(CHANGELOG_PATH));
+		changelog = Deno.readTextFileSync(CHANGELOG_PATH);
 	} catch {
-		return false;
+		return null;
 	}
+	const section = unreleased_section(changelog);
+	if (section === null) return null;
+	return section.replace(/^<!-- bump: (?:patch|minor|major) -->$/m, '').trim();
+}
+
+/** The `<!-- bump: <level> -->` marker declared in the Unreleased section, or null. */
+function changelog_declared_bump(): BumpLevel | null {
+	let changelog: string;
+	try {
+		changelog = Deno.readTextFileSync(CHANGELOG_PATH);
+	} catch {
+		return null;
+	}
+	const section = unreleased_section(changelog);
+	if (section === null) return null;
+	const m = /^<!-- bump: (patch|minor|major) -->$/m.exec(section);
+	return m ? (m[1] as BumpLevel) : null;
+}
+
+/** The bump level — required on BOTH the --bump flag and the CHANGELOG marker,
+ * and they must match. Exits if either is missing or they disagree. */
+function resolve_bump(flag: BumpLevel | null, declared: BumpLevel | null): BumpLevel {
+	if (!flag) {
+		console.error('  FAIL: --bump patch|minor|major is required (and must match the CHANGELOG marker)');
+		Deno.exit(1);
+	}
+	if (!declared) {
+		console.error(
+			`  FAIL: no "<!-- bump: <level> -->" marker under ## Unreleased in ${CHANGELOG_PATH} — declare the bump there too`,
+		);
+		Deno.exit(1);
+	}
+	if (flag !== declared) {
+		console.error(
+			`  FAIL: --bump ${flag} disagrees with CHANGELOG marker <!-- bump: ${declared} --> (they must match)`,
+		);
+		Deno.exit(1);
+	}
+	return flag;
 }
 
 /**

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -503,7 +503,9 @@ function bump_version(current: string, level: 'patch' | 'minor' | 'major'): stri
 	return `${major}.${minor}.${patch + 1}`;
 }
 
-/** Convert CHANGELOG.md's `## Unreleased` section into `## <version>`. */
+/** Stamp CHANGELOG.md's `## Unreleased` section into `## <version>` (dropping its
+ * bump marker) and seed a fresh empty `## Unreleased` reset to `bump: patch` for
+ * the next cycle. Idempotent: a no-op if `## <version>` is already present. */
 function stamp_changelog(new_version: string): void {
 	let changelog: string;
 	try {
@@ -513,14 +515,29 @@ function stamp_changelog(new_version: string): void {
 		console.warn(`  WARN: no ${CHANGELOG_PATH} — skipping changelog stamp`);
 		return;
 	}
-	if (/^## Unreleased$/m.test(changelog)) {
-		const stamped = changelog
-			.replace(/^## Unreleased$/m, `## ${new_version}`)
-			.replace(/^<!-- bump: (?:patch|minor|major) -->\n/m, '');
-		Deno.writeTextFileSync(CHANGELOG_PATH, stamped);
-		console.log(`  Stamped ${CHANGELOG_PATH}: ## Unreleased -> ## ${new_version}`);
-	} else if (version_heading_re(new_version).test(changelog)) {
+	// Already stamped this version (retry after a failed wetrun) — the seeded
+	// fresh `## Unreleased` is expected; leave everything as-is.
+	if (version_heading_re(new_version).test(changelog)) {
 		console.log(`  ${CHANGELOG_PATH} already stamped with ## ${new_version}`);
+		return;
+	}
+	// Rename `## Unreleased` to the version (dropping its bump marker) and seed a
+	// fresh empty `## Unreleased` reset to `bump: patch` for the next cycle.
+	const fresh = '## Unreleased\n<!-- bump: patch -->\n\n';
+	const with_marker = /^## Unreleased\n<!-- bump: (?:patch|minor|major) -->\n/m;
+	if (with_marker.test(changelog)) {
+		const stamped = changelog.replace(with_marker, `${fresh}## ${new_version}\n`);
+		Deno.writeTextFileSync(CHANGELOG_PATH, stamped);
+		console.log(
+			`  Stamped ${CHANGELOG_PATH}: ## Unreleased -> ## ${new_version}; seeded fresh ## Unreleased (bump: patch)`,
+		);
+	} else if (/^## Unreleased$/m.test(changelog)) {
+		// No marker (defensive — a wetrun would have failed earlier). Rename + seed.
+		const stamped = changelog.replace(/^## Unreleased$/m, `${fresh}## ${new_version}`);
+		Deno.writeTextFileSync(CHANGELOG_PATH, stamped);
+		console.log(
+			`  Stamped ${CHANGELOG_PATH}: ## Unreleased -> ## ${new_version}; seeded fresh ## Unreleased (bump: patch)`,
+		);
 	} else {
 		console.warn(`  WARN: no "## Unreleased" section in ${CHANGELOG_PATH} — nothing to stamp`);
 	}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -557,6 +557,15 @@ function unreleased_section(changelog: string): string | null {
 	return next === -1 ? after : after.slice(0, next);
 }
 
+/** The `<!-- bump: <level> -->` marker, recognized ONLY on the line directly
+ * after the `## Unreleased` heading — the exact position `stamp_changelog`'s
+ * `with_marker` rewrites. `unreleased_section` returns the body starting at the
+ * newline after the heading, so the leading `\n` here anchors that placement.
+ * A marker anywhere else in the section is ignored, so validation can't accept
+ * a changelog whose marker the stamper would fail to strip. Kept in sync with
+ * `with_marker`. */
+const UNRELEASED_BUMP_MARKER = /^\n<!-- bump: (patch|minor|major) -->(?:\n|$)/;
+
 /** Unreleased content with the bump marker + surrounding whitespace stripped.
  * `''` means an empty section; `null` means no section (or no CHANGELOG). */
 function changelog_unreleased_content(): string | null {
@@ -568,10 +577,11 @@ function changelog_unreleased_content(): string | null {
 	}
 	const section = unreleased_section(changelog);
 	if (section === null) return null;
-	return section.replace(/^<!-- bump: (?:patch|minor|major) -->$/m, '').trim();
+	return section.replace(UNRELEASED_BUMP_MARKER, '').trim();
 }
 
-/** The `<!-- bump: <level> -->` marker declared in the Unreleased section, or null. */
+/** The `<!-- bump: <level> -->` marker declared directly after the `## Unreleased`
+ * heading, or null. */
 function changelog_declared_bump(): BumpLevel | null {
 	let changelog: string;
 	try {
@@ -581,7 +591,7 @@ function changelog_declared_bump(): BumpLevel | null {
 	}
 	const section = unreleased_section(changelog);
 	if (section === null) return null;
-	const m = /^<!-- bump: (patch|minor|major) -->$/m.exec(section);
+	const m = UNRELEASED_BUMP_MARKER.exec(section);
 	return m ? (m[1] as BumpLevel) : null;
 }
 


### PR DESCRIPTION
As described in discussion https://github.com/fuzdev/tsv/discussions/1, tsv will no longer support configuration of any kind. This keeps usage simple and free of any hidden behavior, not to mention dramatically simplifying parts of the internals that would have been required for Prettier parity.