### PR TITLE
fix: preserve template trailing line comments instead of swallowing trailing braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ non-empty and carry a `<!-- bump: patch|minor|major -->` marker; `deno task publ
 <!-- bump: minor -->
 
 - various conformance fixes
+- fix: a trailing JS **line** comment before a Svelte template construct's closing
+  `}` (e.g. `{expr // c}`, `{#if cond // c}`, `on:click={fn // c}`, `{@const x = e // c}`)
+  no longer emits invalid output — previously the `}` was placed on the comment's
+  line and swallowed (`{expr // c}` reparsed with no closing brace). The comment is
+  now preserved with `}` kept on its own line. Covers expression tags, `{@html}` /
+  `{@render}` / `{@debug}` / `{@const}` tags, `{#if}` / `{:else if}` / `{#each}`
+  (collection + key) / `{#await}` / `{#key}` blocks, and `{...spread}` / `bind:` /
+  `on:` / `class:` / `use:` / `transition:` / `animate:` / `let:` / `data-attr` /
+  `style:` attributes. Prettier drops these comments; tsv preserves them
+  (`expr_trailing_line` divergence)
 - formatting is now **non-configurable by design** — no config files, CLI flags,
   or runtime options, and none are planned (opinionated like `gofmt` and Black).
   Reverses the earlier "config options will come later" note in the docs. No

--- a/crates/tsv_svelte/src/printer/attributes.rs
+++ b/crates/tsv_svelte/src/printer/attributes.rs
@@ -93,10 +93,20 @@ impl<'a> Printer<'a> {
         }
     }
 
-    /// Build a Doc for a trailing JS comment (after content)
+    /// Build a Doc for a trailing JS comment (after content), before a closing
+    /// `}` / `)` / ` as ` token emitted by the caller.
     ///
-    /// Block comments: ` /*content*/` (with leading space)
-    /// Line comments: ` // content` (with leading space, no hardline)
+    /// Block comments: ` /*content*/` (inline, leading space) — the closing token
+    /// follows on the same line.
+    /// Line comments: ` // content` + `hardline` — a `//` comment runs to end of
+    /// line, so the closing token MUST drop to the next line; otherwise it would be
+    /// swallowed into the comment and lost on reparse. Unlike a trailing line comment
+    /// on a TypeScript statement (deferred past the `;` via `line_suffix`), here the
+    /// brace stays in expression context — text past `}` is Svelte template text, so
+    /// `line_suffix` would render the comment on the page. Keeping `}` on its own line
+    /// is the only placement that preserves the comment and stays idempotent. See
+    /// `docs/conformance_prettier.md` §Comment Position Philosophy and the
+    /// `expr_trailing_line` divergence fixture.
     pub(super) fn build_trailing_js_comment_doc(&self, comment: &tsv_lang::Comment) -> DocId {
         let d = self.d();
         if comment.is_block {
@@ -107,7 +117,11 @@ impl<'a> Printer<'a> {
             ])
         } else {
             // Content already includes the space after // (e.g., " comment" from "// comment")
-            d.concat(&[d.text(" //"), d.text_owned(comment.content.clone())])
+            d.concat(&[
+                d.text(" //"),
+                d.text_owned(comment.content.clone()),
+                d.hardline(),
+            ])
         }
     }
 
@@ -518,8 +532,15 @@ impl<'a> Printer<'a> {
                 | tsv_ts::ast::internal::Expression::BinaryExpression(_)
         );
 
+        // A trailing line comment already forces `}` onto its own line (its doc ends
+        // in a hardline). Hug it directly — block structure would add its own softline
+        // before `}`, leaving a stray blank line (`={\n\texpr // c\n\n}`).
+        let has_trailing_line_comment = tag_span.is_some_and(|span| {
+            tsv_lang::has_line_comments_in_range(self.comments, expr.span().end, span.end - 1)
+        });
+
         let d = self.d();
-        let inner = if is_hugged {
+        let inner = if is_hugged || has_trailing_line_comment {
             // Hugged: the expression's internal doc handles wrapping
             let content = d.concat(&expr_content);
             d.concat(&[d.text("{"), content, d.text("}")])
@@ -675,22 +696,19 @@ impl<'a> Printer<'a> {
         let d = self.d();
         let mut parts = vec![d.text("{")];
 
-        // Add leading comments between { and expression
+        // Add leading comments between { and expression (block inline, line + hardline)
         let expr_start = tag.expression.span().start;
         for comment in tsv_lang::comments_in_range(self.comments, tag.span.start + 1, expr_start) {
-            if comment.is_block {
-                parts.push(d.text_owned(format!("/*{}*/ ", comment.content)));
-            }
+            parts.push(self.build_leading_js_comment_doc(comment));
         }
 
         parts.push(self.build_expression_doc_for_attribute(&tag.expression));
 
-        // Add trailing comments (block comments only in expression tags)
+        // Add trailing comments. A line comment forces `}` onto its own line (the
+        // helper appends a hardline) so the `//` doesn't swallow the brace.
         let expr_end = tag.expression.span().end;
         for comment in tsv_lang::comments_in_range(self.comments, expr_end, tag.span.end - 1) {
-            if comment.is_block {
-                parts.push(d.text_owned(format!(" /*{}*/", comment.content)));
-            }
+            parts.push(self.build_trailing_js_comment_doc(comment));
         }
 
         parts.push(d.text("}"));

--- a/crates/tsv_svelte/src/printer/nodes/helpers.rs
+++ b/crates/tsv_svelte/src/printer/nodes/helpers.rs
@@ -60,10 +60,16 @@ impl<'a> Printer<'a> {
         }
     }
 
-    /// Write a JS comment as a trailing comment (after content)
+    /// Write a JS comment as a trailing comment (after content), before a closing
+    /// `}` emitted by the caller.
     ///
-    /// Block comments: ` /*content*/` (with leading space)
-    /// Line comments: ` // content` (with leading space, no newline)
+    /// Block comments: ` /*content*/` (inline; the `}` follows on the same line).
+    /// Line comments: ` // content` + newline + indent — a `//` comment runs to end
+    /// of line, so the closing `}` MUST drop to the next line; otherwise it would be
+    /// swallowed into the comment and lost on reparse. This mirrors the doc-path
+    /// `build_trailing_js_comment_doc` (which appends a `hardline`); the buffer here
+    /// writes the newline + current indent directly. See `build_trailing_js_comment_doc`
+    /// for why `line_suffix`/inline is not an option in template context.
     pub(crate) fn write_trailing_js_comment(&mut self, comment: &tsv_lang::Comment) {
         if comment.is_block {
             self.write(" /*");
@@ -73,6 +79,8 @@ impl<'a> Printer<'a> {
             // Content already includes the space after // (e.g., " comment" from "// comment")
             self.write(" //");
             self.write(&comment.content);
+            self.write("\n");
+            self.write_indent();
         }
     }
 

--- a/docs/conformance_prettier.md
+++ b/docs/conformance_prettier.md
@@ -203,7 +203,7 @@ Prettier preserves byte-order marks. tsv strips them (they serve no purpose in U
 
 ### Svelte: Attributes
 
-**Trailing comments in `{...}`** (content preservation) — [expr_trailing](../tests/fixtures/svelte/syntax/comments/expr_trailing_prettier_divergence/).
+**Trailing comments in `{...}`** (content preservation) — [expr_trailing](../tests/fixtures/svelte/syntax/comments/expr_trailing_prettier_divergence/) (block comments, inline); [expr_trailing_line](../tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/) (line comments — `}` kept on its own line so the `//` doesn't swallow it).
 
 ### Svelte: Blocks
 

--- a/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/README.md
@@ -1,0 +1,41 @@
+# expr_trailing_line_prettier_divergence
+
+The line-comment counterpart of [expr_trailing](./../expr_trailing_prettier_divergence/):
+prettier drops trailing comments in template expressions; tsv preserves them. Because a
+`//` line comment runs to end of line, the closing `}` cannot follow it on the same line —
+it would be swallowed on reparse — so tsv keeps the comment trailing the expression and
+moves `}` to its own line.
+
+tsv:
+
+```svelte
+{foo // c
+}
+```
+
+Prettier: `{foo}` (comment stripped).
+
+The closing brace stays in JS/expression context here, so the comment cannot be deferred
+past `}` (the way a trailing line comment is in a TypeScript statement, via `lineSuffix`):
+text after `}` is Svelte template **text**, so `{foo} // c` would render the literal
+`// c` on the page. Keeping `}` on the next line is the only placement that both preserves
+the comment and stays idempotent.
+
+Affected contexts mirror the block-comment sibling, plus the buffer-printed tags:
+`{expr}`, `{@html}`, `{@render}`, `{@debug}`, `{@const}`, `{#if}` / `{:else if}`,
+`{#each}` (collection and key), `{#await}`, `{#key}`, `{...spread}`, `bind:value={}`,
+`{@attach}`, `data-attr={}`, `on:event={}`, `class:name={}`, `use:action={}`.
+
+Prettier also produces broken output for `{@const x = value // c}` (unmatched paren in
+output), so it is not a usable oracle for that context.
+
+## Reason
+
+User comments are valuable and shouldn't be silently removed. The comments are
+syntactically valid in these positions. See
+[conformance_prettier.md §Comment Position Philosophy](../../../../../docs/conformance_prettier.md#comment-position-philosophy).
+
+## Related
+
+- [expr_trailing](./../expr_trailing_prettier_divergence/) — same divergence for block comments (inline, single-line)
+- [debug_comment](../../tags/debug/debug_comment_prettier_divergence/) — same pattern for `{@debug}`

--- a/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/expected.json
+++ b/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/expected.json
@@ -1,0 +1,1572 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 603,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "ExpressionTag",
+				"start": 0,
+				"end": 11,
+				"expression": {
+					"type": "Identifier",
+					"start": 1,
+					"end": 4,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 1
+						},
+						"end": {
+							"line": 1,
+							"column": 4
+						}
+					},
+					"name": "foo",
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 5,
+							"end": 9
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 11,
+				"end": 12,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "HtmlTag",
+				"start": 12,
+				"end": 30,
+				"expression": {
+					"type": "Identifier",
+					"start": 19,
+					"end": 23,
+					"loc": {
+						"start": {
+							"line": 3,
+							"column": 7
+						},
+						"end": {
+							"line": 3,
+							"column": 11
+						}
+					},
+					"name": "expr",
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 24,
+							"end": 28
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 30,
+				"end": 31,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RenderTag",
+				"start": 31,
+				"end": 51,
+				"expression": {
+					"type": "CallExpression",
+					"start": 40,
+					"end": 44,
+					"loc": {
+						"start": {
+							"line": 5,
+							"column": 9
+						},
+						"end": {
+							"line": 5,
+							"column": 13
+						}
+					},
+					"callee": {
+						"type": "Identifier",
+						"start": 40,
+						"end": 42,
+						"loc": {
+							"start": {
+								"line": 5,
+								"column": 9
+							},
+							"end": {
+								"line": 5,
+								"column": 11
+							}
+						},
+						"name": "fn"
+					},
+					"arguments": [],
+					"optional": false,
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 45,
+							"end": 49
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 51,
+				"end": 52,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "DebugTag",
+				"start": 52,
+				"end": 68,
+				"identifiers": [
+					{
+						"type": "Identifier",
+						"start": 60,
+						"end": 61,
+						"loc": {
+							"start": {
+								"line": 7,
+								"column": 8
+							},
+							"end": {
+								"line": 7,
+								"column": 9
+							}
+						},
+						"name": "x",
+						"trailingComments": [
+							{
+								"type": "Line",
+								"value": " c",
+								"start": 62,
+								"end": 66
+							}
+						]
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 68,
+				"end": 69,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 69,
+				"end": 93,
+				"test": {
+					"type": "Identifier",
+					"start": 74,
+					"end": 78,
+					"loc": {
+						"start": {
+							"line": 9,
+							"column": 5
+						},
+						"end": {
+							"line": 9,
+							"column": 9
+						}
+					},
+					"name": "cond",
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 79,
+							"end": 83
+						}
+					]
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 85,
+							"end": 88,
+							"raw": "yes",
+							"data": "yes"
+						}
+					]
+				},
+				"alternate": null
+			},
+			{
+				"type": "Text",
+				"start": 93,
+				"end": 94,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 94,
+				"end": 126,
+				"test": {
+					"type": "Identifier",
+					"start": 99,
+					"end": 100,
+					"loc": {
+						"start": {
+							"line": 11,
+							"column": 5
+						},
+						"end": {
+							"line": 11,
+							"column": 6
+						}
+					},
+					"name": "a"
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 101,
+							"end": 102,
+							"raw": "a",
+							"data": "a"
+						}
+					]
+				},
+				"alternate": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"start": 102,
+							"end": 126,
+							"type": "IfBlock",
+							"elseif": true,
+							"test": {
+								"type": "Identifier",
+								"start": 112,
+								"end": 113,
+								"loc": {
+									"start": {
+										"line": 11,
+										"column": 18
+									},
+									"end": {
+										"line": 11,
+										"column": 19
+									}
+								},
+								"name": "b",
+								"trailingComments": [
+									{
+										"type": "Line",
+										"value": " c",
+										"start": 114,
+										"end": 118
+									}
+								]
+							},
+							"consequent": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 120,
+										"end": 121,
+										"raw": "b",
+										"data": "b"
+									}
+								]
+							},
+							"alternate": null
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 126,
+				"end": 127,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "EachBlock",
+				"start": 127,
+				"end": 167,
+				"expression": {
+					"type": "Identifier",
+					"start": 134,
+					"end": 139,
+					"loc": {
+						"start": {
+							"line": 13,
+							"column": 7
+						},
+						"end": {
+							"line": 13,
+							"column": 12
+						}
+					},
+					"name": "items",
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 140,
+							"end": 144
+						}
+					]
+				},
+				"body": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "ExpressionTag",
+							"start": 154,
+							"end": 160,
+							"expression": {
+								"type": "Identifier",
+								"start": 155,
+								"end": 159,
+								"loc": {
+									"start": {
+										"line": 14,
+										"column": 10
+									},
+									"end": {
+										"line": 14,
+										"column": 14
+									}
+								},
+								"name": "item"
+							}
+						}
+					]
+				},
+				"context": {
+					"type": "Identifier",
+					"name": "item",
+					"start": 149,
+					"end": 153,
+					"loc": {
+						"start": {
+							"line": 14,
+							"column": 4,
+							"character": 149
+						},
+						"end": {
+							"line": 14,
+							"column": 8,
+							"character": 153
+						}
+					}
+				}
+			},
+			{
+				"type": "Text",
+				"start": 167,
+				"end": 168,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "EachBlock",
+				"start": 168,
+				"end": 218,
+				"expression": {
+					"type": "Identifier",
+					"start": 175,
+					"end": 180,
+					"loc": {
+						"start": {
+							"line": 15,
+							"column": 7
+						},
+						"end": {
+							"line": 15,
+							"column": 12
+						}
+					},
+					"name": "items"
+				},
+				"body": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "ExpressionTag",
+							"start": 205,
+							"end": 211,
+							"expression": {
+								"type": "Identifier",
+								"start": 206,
+								"end": 210,
+								"loc": {
+									"start": {
+										"line": 16,
+										"column": 3
+									},
+									"end": {
+										"line": 16,
+										"column": 7
+									}
+								},
+								"name": "item"
+							}
+						}
+					]
+				},
+				"context": {
+					"type": "Identifier",
+					"name": "item",
+					"start": 184,
+					"end": 188,
+					"loc": {
+						"start": {
+							"line": 15,
+							"column": 16,
+							"character": 184
+						},
+						"end": {
+							"line": 15,
+							"column": 20,
+							"character": 188
+						}
+					}
+				},
+				"key": {
+					"type": "MemberExpression",
+					"start": 190,
+					"end": 197,
+					"loc": {
+						"start": {
+							"line": 15,
+							"column": 22
+						},
+						"end": {
+							"line": 15,
+							"column": 29
+						}
+					},
+					"object": {
+						"type": "Identifier",
+						"start": 190,
+						"end": 194,
+						"loc": {
+							"start": {
+								"line": 15,
+								"column": 22
+							},
+							"end": {
+								"line": 15,
+								"column": 26
+							}
+						},
+						"name": "item"
+					},
+					"property": {
+						"type": "Identifier",
+						"start": 195,
+						"end": 197,
+						"loc": {
+							"start": {
+								"line": 15,
+								"column": 27
+							},
+							"end": {
+								"line": 15,
+								"column": 29
+							}
+						},
+						"name": "id"
+					},
+					"computed": false,
+					"optional": false,
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 198,
+							"end": 202
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 218,
+				"end": 219,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "AwaitBlock",
+				"start": 219,
+				"end": 263,
+				"expression": {
+					"type": "Identifier",
+					"start": 227,
+					"end": 234,
+					"loc": {
+						"start": {
+							"line": 17,
+							"column": 8
+						},
+						"end": {
+							"line": 17,
+							"column": 15
+						}
+					},
+					"name": "promise",
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 235,
+							"end": 239
+						}
+					]
+				},
+				"value": {
+					"type": "Identifier",
+					"name": "val",
+					"start": 246,
+					"end": 249,
+					"loc": {
+						"start": {
+							"line": 18,
+							"column": 6,
+							"character": 246
+						},
+						"end": {
+							"line": 18,
+							"column": 9,
+							"character": 249
+						}
+					}
+				},
+				"error": null,
+				"pending": null,
+				"then": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "ExpressionTag",
+							"start": 250,
+							"end": 255,
+							"expression": {
+								"type": "Identifier",
+								"start": 251,
+								"end": 254,
+								"loc": {
+									"start": {
+										"line": 18,
+										"column": 11
+									},
+									"end": {
+										"line": 18,
+										"column": 14
+									}
+								},
+								"name": "val"
+							}
+						}
+					]
+				},
+				"catch": null
+			},
+			{
+				"type": "Text",
+				"start": 263,
+				"end": 264,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "KeyBlock",
+				"start": 264,
+				"end": 291,
+				"expression": {
+					"type": "Identifier",
+					"start": 270,
+					"end": 274,
+					"loc": {
+						"start": {
+							"line": 19,
+							"column": 6
+						},
+						"end": {
+							"line": 19,
+							"column": 10
+						}
+					},
+					"name": "expr",
+					"trailingComments": [
+						{
+							"type": "Line",
+							"value": " c",
+							"start": 275,
+							"end": 279
+						}
+					]
+				},
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 281,
+							"end": 285,
+							"raw": "text",
+							"data": "text"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 291,
+				"end": 292,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "EachBlock",
+				"start": 292,
+				"end": 343,
+				"expression": {
+					"type": "Identifier",
+					"start": 299,
+					"end": 303,
+					"loc": {
+						"start": {
+							"line": 21,
+							"column": 7
+						},
+						"end": {
+							"line": 21,
+							"column": 11
+						}
+					},
+					"name": "list"
+				},
+				"body": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "ConstTag",
+							"start": 310,
+							"end": 332,
+							"declaration": {
+								"type": "VariableDeclaration",
+								"kind": "const",
+								"declarations": [
+									{
+										"type": "VariableDeclarator",
+										"id": {
+											"type": "Identifier",
+											"name": "y",
+											"start": 318,
+											"end": 319,
+											"loc": {
+												"start": {
+													"line": 21,
+													"column": 26,
+													"character": 318
+												},
+												"end": {
+													"line": 21,
+													"column": 27,
+													"character": 319
+												}
+											}
+										},
+										"init": {
+											"type": "Identifier",
+											"start": 322,
+											"end": 324,
+											"loc": {
+												"start": {
+													"line": 21,
+													"column": 30
+												},
+												"end": {
+													"line": 21,
+													"column": 32
+												}
+											},
+											"name": "it",
+											"trailingComments": [
+												{
+													"type": "Line",
+													"value": " c",
+													"start": 325,
+													"end": 329
+												}
+											]
+										},
+										"start": 318,
+										"end": 324
+									}
+								],
+								"start": 312,
+								"end": 331
+							}
+						},
+						{
+							"type": "ExpressionTag",
+							"start": 332,
+							"end": 336,
+							"expression": {
+								"type": "Identifier",
+								"start": 333,
+								"end": 335,
+								"loc": {
+									"start": {
+										"line": 22,
+										"column": 3
+									},
+									"end": {
+										"line": 22,
+										"column": 5
+									}
+								},
+								"name": "it"
+							}
+						}
+					]
+				},
+				"context": {
+					"type": "Identifier",
+					"name": "it",
+					"start": 307,
+					"end": 309,
+					"loc": {
+						"start": {
+							"line": 21,
+							"column": 15,
+							"character": 307
+						},
+						"end": {
+							"line": 21,
+							"column": 17,
+							"character": 309
+						}
+					}
+				}
+			},
+			{
+				"type": "Text",
+				"start": 343,
+				"end": 344,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 344,
+				"end": 374,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 23,
+						"column": 1,
+						"character": 345
+					},
+					"end": {
+						"line": 23,
+						"column": 4,
+						"character": 348
+					}
+				},
+				"attributes": [
+					{
+						"type": "SpreadAttribute",
+						"start": 350,
+						"end": 366,
+						"expression": {
+							"type": "Identifier",
+							"start": 354,
+							"end": 358,
+							"loc": {
+								"start": {
+									"line": 24,
+									"column": 5
+								},
+								"end": {
+									"line": 24,
+									"column": 9
+								}
+							},
+							"name": "expr",
+							"trailingComments": [
+								{
+									"type": "Line",
+									"value": " c",
+									"start": 359,
+									"end": 363
+								}
+							]
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 374,
+				"end": 375,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 375,
+				"end": 409,
+				"name": "input",
+				"name_loc": {
+					"start": {
+						"line": 27,
+						"column": 1,
+						"character": 376
+					},
+					"end": {
+						"line": 27,
+						"column": 6,
+						"character": 381
+					}
+				},
+				"attributes": [
+					{
+						"start": 383,
+						"end": 406,
+						"type": "BindDirective",
+						"name": "value",
+						"name_loc": {
+							"start": {
+								"line": 28,
+								"column": 1,
+								"character": 383
+							},
+							"end": {
+								"line": 28,
+								"column": 11,
+								"character": 393
+							}
+						},
+						"expression": {
+							"type": "Identifier",
+							"start": 395,
+							"end": 398,
+							"loc": {
+								"start": {
+									"line": 28,
+									"column": 13
+								},
+								"end": {
+									"line": 28,
+									"column": 16
+								}
+							},
+							"name": "val",
+							"trailingComments": [
+								{
+									"type": "Line",
+									"value": " c",
+									"start": 399,
+									"end": 403
+								}
+							]
+						},
+						"modifiers": []
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 409,
+				"end": 410,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 410,
+				"end": 443,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 31,
+						"column": 1,
+						"character": 411
+					},
+					"end": {
+						"line": 31,
+						"column": 4,
+						"character": 414
+					}
+				},
+				"attributes": [
+					{
+						"type": "AttachTag",
+						"start": 416,
+						"end": 435,
+						"expression": {
+							"type": "Identifier",
+							"start": 425,
+							"end": 427,
+							"loc": {
+								"start": {
+									"line": 32,
+									"column": 10
+								},
+								"end": {
+									"line": 32,
+									"column": 12
+								}
+							},
+							"name": "fn",
+							"trailingComments": [
+								{
+									"type": "Line",
+									"value": " c",
+									"start": 428,
+									"end": 432
+								}
+							]
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 443,
+				"end": 444,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 444,
+				"end": 481,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 35,
+						"column": 1,
+						"character": 445
+					},
+					"end": {
+						"line": 35,
+						"column": 4,
+						"character": 448
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 450,
+						"end": 473,
+						"name": "data-attr",
+						"name_loc": {
+							"start": {
+								"line": 36,
+								"column": 1,
+								"character": 450
+							},
+							"end": {
+								"line": 36,
+								"column": 10,
+								"character": 459
+							}
+						},
+						"value": {
+							"type": "ExpressionTag",
+							"start": 460,
+							"end": 473,
+							"expression": {
+								"type": "Identifier",
+								"start": 461,
+								"end": 465,
+								"loc": {
+									"start": {
+										"line": 36,
+										"column": 12
+									},
+									"end": {
+										"line": 36,
+										"column": 16
+									}
+								},
+								"name": "expr",
+								"trailingComments": [
+									{
+										"type": "Line",
+										"value": " c",
+										"start": 466,
+										"end": 470
+									}
+								]
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 481,
+				"end": 482,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 482,
+				"end": 526,
+				"name": "button",
+				"name_loc": {
+					"start": {
+						"line": 39,
+						"column": 1,
+						"character": 483
+					},
+					"end": {
+						"line": 39,
+						"column": 7,
+						"character": 489
+					}
+				},
+				"attributes": [
+					{
+						"start": 491,
+						"end": 511,
+						"type": "OnDirective",
+						"name": "click",
+						"name_loc": {
+							"start": {
+								"line": 40,
+								"column": 1,
+								"character": 491
+							},
+							"end": {
+								"line": 40,
+								"column": 9,
+								"character": 499
+							}
+						},
+						"expression": {
+							"type": "Identifier",
+							"start": 501,
+							"end": 503,
+							"loc": {
+								"start": {
+									"line": 40,
+									"column": 11
+								},
+								"end": {
+									"line": 40,
+									"column": 13
+								}
+							},
+							"name": "fn",
+							"trailingComments": [
+								{
+									"type": "Line",
+									"value": " c",
+									"start": 504,
+									"end": 508
+								}
+							]
+						},
+						"modifiers": []
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 512,
+							"end": 516,
+							"raw": "text",
+							"data": "text"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 526,
+				"end": 527,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 527,
+				"end": 567,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 43,
+						"column": 1,
+						"character": 528
+					},
+					"end": {
+						"line": 43,
+						"column": 4,
+						"character": 531
+					}
+				},
+				"attributes": [
+					{
+						"start": 533,
+						"end": 559,
+						"type": "ClassDirective",
+						"name": "class1",
+						"name_loc": {
+							"start": {
+								"line": 44,
+								"column": 1,
+								"character": 533
+							},
+							"end": {
+								"line": 44,
+								"column": 13,
+								"character": 545
+							}
+						},
+						"expression": {
+							"type": "Identifier",
+							"start": 547,
+							"end": 551,
+							"loc": {
+								"start": {
+									"line": 44,
+									"column": 15
+								},
+								"end": {
+									"line": 44,
+									"column": 19
+								}
+							},
+							"name": "cond",
+							"trailingComments": [
+								{
+									"type": "Line",
+									"value": " c",
+									"start": 552,
+									"end": 556
+								}
+							]
+						},
+						"modifiers": []
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 567,
+				"end": 568,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 568,
+				"end": 602,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 47,
+						"column": 1,
+						"character": 569
+					},
+					"end": {
+						"line": 47,
+						"column": 4,
+						"character": 572
+					}
+				},
+				"attributes": [
+					{
+						"start": 574,
+						"end": 594,
+						"type": "UseDirective",
+						"name": "fn",
+						"name_loc": {
+							"start": {
+								"line": 48,
+								"column": 1,
+								"character": 574
+							},
+							"end": {
+								"line": 48,
+								"column": 7,
+								"character": 580
+							}
+						},
+						"expression": {
+							"type": "Identifier",
+							"start": 582,
+							"end": 586,
+							"loc": {
+								"start": {
+									"line": 48,
+									"column": 9
+								},
+								"end": {
+									"line": 48,
+									"column": 13
+								}
+							},
+							"name": "expr",
+							"trailingComments": [
+								{
+									"type": "Line",
+									"value": " c",
+									"start": 587,
+									"end": 591
+								}
+							]
+						},
+						"modifiers": []
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			}
+		]
+	},
+	"options": null,
+	"comments": [
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 5,
+			"end": 9,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 5
+				},
+				"end": {
+					"line": 1,
+					"column": 9
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 24,
+			"end": 28,
+			"loc": {
+				"start": {
+					"line": 3,
+					"column": 12
+				},
+				"end": {
+					"line": 3,
+					"column": 16
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 45,
+			"end": 49,
+			"loc": {
+				"start": {
+					"line": 5,
+					"column": 14
+				},
+				"end": {
+					"line": 5,
+					"column": 18
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 62,
+			"end": 66,
+			"loc": {
+				"start": {
+					"line": 7,
+					"column": 10
+				},
+				"end": {
+					"line": 7,
+					"column": 14
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 79,
+			"end": 83,
+			"loc": {
+				"start": {
+					"line": 9,
+					"column": 10
+				},
+				"end": {
+					"line": 9,
+					"column": 14
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 114,
+			"end": 118,
+			"loc": {
+				"start": {
+					"line": 11,
+					"column": 20
+				},
+				"end": {
+					"line": 11,
+					"column": 24
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 140,
+			"end": 144,
+			"loc": {
+				"start": {
+					"line": 13,
+					"column": 13
+				},
+				"end": {
+					"line": 13,
+					"column": 17
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 198,
+			"end": 202,
+			"loc": {
+				"start": {
+					"line": 15,
+					"column": 30
+				},
+				"end": {
+					"line": 15,
+					"column": 34
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 235,
+			"end": 239,
+			"loc": {
+				"start": {
+					"line": 17,
+					"column": 16
+				},
+				"end": {
+					"line": 17,
+					"column": 20
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 275,
+			"end": 279,
+			"loc": {
+				"start": {
+					"line": 19,
+					"column": 11
+				},
+				"end": {
+					"line": 19,
+					"column": 15
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 325,
+			"end": 329,
+			"loc": {
+				"start": {
+					"line": 21,
+					"column": 33
+				},
+				"end": {
+					"line": 21,
+					"column": 37
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 359,
+			"end": 363,
+			"loc": {
+				"start": {
+					"line": 24,
+					"column": 10
+				},
+				"end": {
+					"line": 24,
+					"column": 14
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 399,
+			"end": 403,
+			"loc": {
+				"start": {
+					"line": 28,
+					"column": 17
+				},
+				"end": {
+					"line": 28,
+					"column": 21
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 428,
+			"end": 432,
+			"loc": {
+				"start": {
+					"line": 32,
+					"column": 13
+				},
+				"end": {
+					"line": 32,
+					"column": 17
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 466,
+			"end": 470,
+			"loc": {
+				"start": {
+					"line": 36,
+					"column": 17
+				},
+				"end": {
+					"line": 36,
+					"column": 21
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 504,
+			"end": 508,
+			"loc": {
+				"start": {
+					"line": 40,
+					"column": 14
+				},
+				"end": {
+					"line": 40,
+					"column": 18
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 552,
+			"end": 556,
+			"loc": {
+				"start": {
+					"line": 44,
+					"column": 20
+				},
+				"end": {
+					"line": 44,
+					"column": 24
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " c",
+			"start": 587,
+			"end": 591,
+			"loc": {
+				"start": {
+					"line": 48,
+					"column": 14
+				},
+				"end": {
+					"line": 48,
+					"column": 18
+				}
+			}
+		}
+	]
+}

--- a/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/input.svelte
+++ b/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/input.svelte
@@ -1,0 +1,50 @@
+{foo // c
+}
+{@html expr // c
+}
+{@render fn() // c
+}
+{@debug x // c
+}
+{#if cond // c
+}yes{/if}
+{#if a}a{:else if b // c
+}b{/if}
+{#each items // c
+ as item}{item}{/each}
+{#each items as item (item.id // c
+)}{item}{/each}
+{#await promise // c
+ then val}{val}{/await}
+{#key expr // c
+}text{/key}
+{#each list as it}{@const y = it // c
+	}{it}{/each}
+<div
+	{...expr // c
+	}
+></div>
+<input
+	bind:value={val // c
+	}
+/>
+<div
+	{@attach fn // c
+	}
+></div>
+<div
+	data-attr={expr // c
+	}
+></div>
+<button
+	on:click={fn // c
+	}>text</button
+>
+<div
+	class:class1={cond // c
+	}
+></div>
+<div
+	use:fn={expr // c
+	}
+></div>

--- a/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/output_prettier.svelte
+++ b/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/output_prettier.svelte
@@ -1,0 +1,18 @@
+{foo}
+{@html expr}
+{@render fn()}
+{@debug x}
+{#if cond}yes{/if}
+{#if a}a{:else if b}b{/if}
+{#each items as item}{item}{/each}
+{#each items as item (item.id)}{item}{/each}
+{#await promise then val}{val}{/await}
+{#key expr}text{/key}
+{#each list as it}{@const y = it)}{it}{/each} // c
+<div {...expr}></div>
+<input bind:value={val} />
+<div {@attach fn}></div>
+<div data-attr={expr}></div>
+<button on:click={fn}>text</button>
+<div class:class1={cond}></div>
+<div use:fn={expr}></div>

--- a/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/unformatted_ours_compact.svelte
+++ b/tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/unformatted_ours_compact.svelte
@@ -1,0 +1,36 @@
+{foo // c
+}
+{@html expr // c
+}
+{@render fn() // c
+}
+{@debug x // c
+}
+{#if cond // c
+}yes{/if}
+{#if a}a{:else if b // c
+}b{/if}
+{#each items // c
+ as item}{item}{/each}
+{#each items as item (item.id // c
+)}{item}{/each}
+{#await promise // c
+ then val}{val}{/await}
+{#key expr // c
+}text{/key}
+{#each list as it}{@const y = it // c
+	}{it}{/each}
+<div {...expr // c
+}></div>
+<input bind:value={val // c
+} />
+<div {@attach fn // c
+}></div>
+<div data-attr={expr // c
+}></div>
+<button on:click={fn // c
+}>text</button>
+<div class:class1={cond // c
+}></div>
+<div use:fn={expr // c
+}></div>


### PR DESCRIPTION
fixes `// comments` getting dropped in prettier-plugin-svelte in markup, an unusual pattern