### PR TITLE
fix: preserve same-line line-comment placement in svelte attribute lists

### DIFF
--- a/crates/tsv_svelte/src/printer/nodes/element_doc.rs
+++ b/crates/tsv_svelte/src/printer/nodes/element_doc.rs
@@ -1487,9 +1487,11 @@ impl<'a> Printer<'a> {
 
     /// Push docs for JS comments between attributes.
     ///
-    /// Each comment gets a preceding separator (hardline for own-line, space for inline).
-    /// Returns whether the last comment was on its own line (caller uses this
-    /// to decide the separator before the next attribute).
+    /// Each comment gets a preceding separator (hardline when it starts its own
+    /// line, an inline space when it trails the previous token). Returns whether
+    /// the following attribute must start on a new line — true for any own-line
+    /// comment and for any line comment (a `//` runs to end of line, so the next
+    /// token can't share it); the caller uses this to pick that separator.
     pub(super) fn push_attr_comment_docs(
         &self,
         docs: &mut Vec<DocId>,
@@ -1502,14 +1504,26 @@ impl<'a> Printer<'a> {
             let is_own_line =
                 self.source[range_start as usize..comment.span.start as usize].contains('\n');
 
-            if comment.is_block && !is_own_line {
-                docs.push(d.text(" "));
-                last_was_own_line = false;
-            } else {
+            // Preserve the author's placement: a comment on its own line stays on its
+            // own line; a comment on the same line as the preceding token stays
+            // trailing it (inline). This already held for block comments; it now
+            // extends to line comments (a `//` the author put after the tag name or
+            // an attribute is kept there rather than relocated to its own line).
+            if is_own_line {
                 docs.push(d.hardline());
-                last_was_own_line = true;
+            } else {
+                docs.push(d.text(" "));
             }
             docs.push(self.build_attr_js_comment_doc(comment));
+            if !comment.is_block {
+                // A `//` runs to end of line, so the following attribute or the
+                // closing `>` / `/>` must drop to the next line — force the open-tag
+                // group to break so it can't be swallowed into the comment.
+                docs.push(d.break_parent());
+            }
+            // A line comment always pushes the next token to a new line; a same-line
+            // block comment lets it stay inline.
+            last_was_own_line = is_own_line || !comment.is_block;
         }
         last_was_own_line
     }

--- a/docs/conformance_prettier.md
+++ b/docs/conformance_prettier.md
@@ -205,6 +205,8 @@ Prettier preserves byte-order marks. tsv strips them (they serve no purpose in U
 
 **Trailing comments in `{...}`** (content preservation) — [expr_trailing](../tests/fixtures/svelte/syntax/comments/expr_trailing_prettier_divergence/) (block comments, inline); [expr_trailing_line](../tests/fixtures/svelte/syntax/comments/expr_trailing_line_prettier_divergence/) (line comments — `}` kept on its own line so the `//` doesn't swallow it).
 
+**Same-line `//` comment placement in the attribute list** (placement preservation) — [comment_same_line](../tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/): a line comment the author put on the same line as the tag name (`<div // foo`) or trailing an attribute that has more attributes after it (`a="1" // mid`) stays trailing that token; prettier relocates it to its own line. A `//` trailing the *last* attribute (before `>`/`/>`) already stays inline in both formatters, so it is not a divergence — [comment_trailing_same_line](../tests/fixtures/svelte/attributes/comment_trailing_same_line/). Block comments and own-line comments are preserved as-written by both. See [Comment Position Philosophy](#comment-position-philosophy).
+
 ### Svelte: Blocks
 
 - `{#each}` line wrap — [each_long](../tests/fixtures/svelte/blocks/each/long_prettier_divergence/)

--- a/tests/fixtures/svelte/attributes/comment/unformatted_compact.svelte
+++ b/tests/fixtures/svelte/attributes/comment/unformatted_compact.svelte
@@ -1,0 +1,46 @@
+<!-- Line comment between attributes -->
+<div
+data-attr1="value1"
+// line comment
+data-attr2="value2"
+>
+text1
+</div>
+
+<!-- Block comment between attributes -->
+<div
+data-attr1="value1"
+/* block comment */
+data-attr2="value2"
+>
+text2
+</div>
+
+<!-- Comment before first attribute -->
+<div
+// before first
+data-attr="value"
+>
+text3
+</div>
+
+<!-- Multiple consecutive comments -->
+<div
+data-attr1="value1"
+// first
+// second
+data-attr2="value2"
+>
+text4
+</div>
+
+<!-- Trailing comment after last attribute -->
+<div
+data-attr="value"
+// trailing
+>
+text5
+</div>
+
+<!-- Inline block comment -->
+<div data-attr1="value1"/* inline */data-attr2="value2">text6</div>

--- a/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/README.md
@@ -1,0 +1,52 @@
+# comment_same_line_prettier_divergence
+
+A `//` line comment that the author placed on the same line as the tag name or an
+attribute stays trailing that token; prettier moves it to its own line.
+
+tsv:
+
+```svelte
+<div // foo
+	data-attr="value"
+>…
+
+<div
+	data-attr1="value1" // mid
+	data-attr2="value2"
+>…
+```
+
+Prettier moves `// foo` and `// mid` onto their own lines:
+
+```svelte
+<div
+	// foo
+	data-attr="value"
+>…
+
+<div
+	data-attr1="value1"
+	// mid
+	data-attr2="value2"
+>…
+```
+
+Because a `//` comment runs to end of line, the following attribute (or the closing
+`>` / `/>`) must drop to the next line either way — the only question is whether the
+comment leads the next line or trails the previous token. tsv preserves where the
+author wrote it; prettier always leads.
+
+A `//` comment trailing the **last** attribute (before `>` / `/>`) stays inline in both
+formatters, so that position is not a divergence — see
+[comment_trailing_same_line](../comment_trailing_same_line/). Block comments and
+own-line comments are preserved as-written by both.
+
+## Reason
+
+Comment placement is a deliberate authoring choice and tsv preserves it. See
+[conformance_prettier.md §Comment Position Philosophy](../../../../../docs/conformance_prettier.md#comment-position-philosophy).
+
+## Related
+
+- [comment_trailing_same_line](../comment_trailing_same_line/) — same-line `//` trailing the last attribute (matches prettier, not a divergence)
+- [comment](../comment/) — own-line attribute-list comments (matches prettier)

--- a/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/expected.json
+++ b/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/expected.json
@@ -1,0 +1,358 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 464,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "Comment",
+				"start": 0,
+				"end": 103,
+				"data": " Line comment after the tag name stays on the tag-name line (prettier moves it to its own line) "
+			},
+			{
+				"type": "Text",
+				"start": 103,
+				"end": 104,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 104,
+				"end": 149,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 2,
+						"column": 1,
+						"character": 105
+					},
+					"end": {
+						"line": 2,
+						"column": 4,
+						"character": 108
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 117,
+						"end": 134,
+						"name": "data-attr",
+						"name_loc": {
+							"start": {
+								"line": 3,
+								"column": 1,
+								"character": 117
+							},
+							"end": {
+								"line": 3,
+								"column": 10,
+								"character": 126
+							}
+						},
+						"value": [
+							{
+								"start": 128,
+								"end": 133,
+								"type": "Text",
+								"raw": "value",
+								"data": "value"
+							}
+						]
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 136,
+							"end": 143,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 149,
+				"end": 151,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 151,
+				"end": 264,
+				"data": " Between-attribute line comment stays trailing the previous attribute (prettier moves it to its own line) "
+			},
+			{
+				"type": "Text",
+				"start": 264,
+				"end": 265,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 265,
+				"end": 333,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 9,
+						"column": 1,
+						"character": 266
+					},
+					"end": {
+						"line": 9,
+						"column": 4,
+						"character": 269
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 271,
+						"end": 290,
+						"name": "data-attr1",
+						"name_loc": {
+							"start": {
+								"line": 10,
+								"column": 1,
+								"character": 271
+							},
+							"end": {
+								"line": 10,
+								"column": 11,
+								"character": 281
+							}
+						},
+						"value": [
+							{
+								"start": 283,
+								"end": 289,
+								"type": "Text",
+								"raw": "value1",
+								"data": "value1"
+							}
+						]
+					},
+					{
+						"type": "Attribute",
+						"start": 299,
+						"end": 318,
+						"name": "data-attr2",
+						"name_loc": {
+							"start": {
+								"line": 11,
+								"column": 1,
+								"character": 299
+							},
+							"end": {
+								"line": 11,
+								"column": 11,
+								"character": 309
+							}
+						},
+						"value": [
+							{
+								"start": 311,
+								"end": 317,
+								"type": "Text",
+								"raw": "value2",
+								"data": "value2"
+							}
+						]
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 320,
+							"end": 327,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 333,
+				"end": 335,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 335,
+				"end": 420,
+				"data": " Combined: after-tag-name comment + trailing comment on a shorthand attribute "
+			},
+			{
+				"type": "Text",
+				"start": 420,
+				"end": 421,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 421,
+				"end": 463,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 17,
+						"column": 1,
+						"character": 422
+					},
+					"end": {
+						"line": 17,
+						"column": 4,
+						"character": 425
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 434,
+						"end": 441,
+						"name": "value",
+						"name_loc": {
+							"start": {
+								"line": 18,
+								"column": 2,
+								"character": 435
+							},
+							"end": {
+								"line": 18,
+								"column": 7,
+								"character": 440
+							}
+						},
+						"value": {
+							"type": "ExpressionTag",
+							"start": 435,
+							"end": 440,
+							"expression": {
+								"type": "Identifier",
+								"name": "value",
+								"start": 435,
+								"end": 440,
+								"loc": {
+									"start": {
+										"line": 18,
+										"column": 2,
+										"character": 435
+									},
+									"end": {
+										"line": 18,
+										"column": 7,
+										"character": 440
+									}
+								}
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 450,
+							"end": 457,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			}
+		]
+	},
+	"options": null,
+	"comments": [
+		{
+			"type": "Line",
+			"start": 109,
+			"end": 115,
+			"value": " foo",
+			"loc": {
+				"start": {
+					"line": 2,
+					"column": 5,
+					"character": 109
+				},
+				"end": {
+					"line": 2,
+					"column": 11,
+					"character": 115
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 291,
+			"end": 297,
+			"value": " mid",
+			"loc": {
+				"start": {
+					"line": 10,
+					"column": 21,
+					"character": 291
+				},
+				"end": {
+					"line": 10,
+					"column": 27,
+					"character": 297
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 426,
+			"end": 432,
+			"value": " foo",
+			"loc": {
+				"start": {
+					"line": 17,
+					"column": 5,
+					"character": 426
+				},
+				"end": {
+					"line": 17,
+					"column": 11,
+					"character": 432
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 442,
+			"end": 448,
+			"value": " bar",
+			"loc": {
+				"start": {
+					"line": 18,
+					"column": 9,
+					"character": 442
+				},
+				"end": {
+					"line": 18,
+					"column": 15,
+					"character": 448
+				}
+			}
+		}
+	]
+}

--- a/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/input.svelte
+++ b/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/input.svelte
@@ -1,0 +1,21 @@
+<!-- Line comment after the tag name stays on the tag-name line (prettier moves it to its own line) -->
+<div // foo
+	data-attr="value"
+>
+	text
+</div>
+
+<!-- Between-attribute line comment stays trailing the previous attribute (prettier moves it to its own line) -->
+<div
+	data-attr1="value1" // mid
+	data-attr2="value2"
+>
+	text
+</div>
+
+<!-- Combined: after-tag-name comment + trailing comment on a shorthand attribute -->
+<div // foo
+	{value} // bar
+>
+	text
+</div>

--- a/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/output_prettier.svelte
+++ b/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/output_prettier.svelte
@@ -1,0 +1,24 @@
+<!-- Line comment after the tag name stays on the tag-name line (prettier moves it to its own line) -->
+<div
+	// foo
+	data-attr="value"
+>
+	text
+</div>
+
+<!-- Between-attribute line comment stays trailing the previous attribute (prettier moves it to its own line) -->
+<div
+	data-attr1="value1"
+	// mid
+	data-attr2="value2"
+>
+	text
+</div>
+
+<!-- Combined: after-tag-name comment + trailing comment on a shorthand attribute -->
+<div
+	// foo
+	{value} // bar
+>
+	text
+</div>

--- a/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/unformatted_ours_compact.svelte
+++ b/tests/fixtures/svelte/attributes/comment_same_line_prettier_divergence/unformatted_ours_compact.svelte
@@ -1,0 +1,21 @@
+<!-- Line comment after the tag name stays on the tag-name line (prettier moves it to its own line) -->
+<div// foo
+data-attr="value"
+>
+text
+</div>
+
+<!-- Between-attribute line comment stays trailing the previous attribute (prettier moves it to its own line) -->
+<div
+data-attr1="value1"// mid
+data-attr2="value2"
+>
+text
+</div>
+
+<!-- Combined: after-tag-name comment + trailing comment on a shorthand attribute -->
+<div// foo
+{value}// bar
+>
+text
+</div>

--- a/tests/fixtures/svelte/attributes/comment_trailing_same_line/expected.json
+++ b/tests/fixtures/svelte/attributes/comment_trailing_same_line/expected.json
@@ -1,0 +1,715 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 754,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "Comment",
+				"start": 0,
+				"end": 66,
+				"data": " Trailing line comment on a regular attribute stays inline "
+			},
+			{
+				"type": "Text",
+				"start": 66,
+				"end": 67,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 67,
+				"end": 117,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 2,
+						"column": 1,
+						"character": 68
+					},
+					"end": {
+						"line": 2,
+						"column": 4,
+						"character": 71
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 73,
+						"end": 90,
+						"name": "data-attr",
+						"name_loc": {
+							"start": {
+								"line": 3,
+								"column": 1,
+								"character": 73
+							},
+							"end": {
+								"line": 3,
+								"column": 10,
+								"character": 82
+							}
+						},
+						"value": [
+							{
+								"start": 84,
+								"end": 89,
+								"type": "Text",
+								"raw": "value",
+								"data": "value"
+							}
+						]
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 104,
+							"end": 111,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 117,
+				"end": 119,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 119,
+				"end": 174,
+				"data": " Trailing line comment on a shorthand attribute "
+			},
+			{
+				"type": "Text",
+				"start": 174,
+				"end": 175,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 175,
+				"end": 215,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 9,
+						"column": 1,
+						"character": 176
+					},
+					"end": {
+						"line": 9,
+						"column": 4,
+						"character": 179
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 181,
+						"end": 188,
+						"name": "value",
+						"name_loc": {
+							"start": {
+								"line": 10,
+								"column": 2,
+								"character": 182
+							},
+							"end": {
+								"line": 10,
+								"column": 7,
+								"character": 187
+							}
+						},
+						"value": {
+							"type": "ExpressionTag",
+							"start": 182,
+							"end": 187,
+							"expression": {
+								"type": "Identifier",
+								"name": "value",
+								"start": 182,
+								"end": 187,
+								"loc": {
+									"start": {
+										"line": 10,
+										"column": 2,
+										"character": 182
+									},
+									"end": {
+										"line": 10,
+										"column": 7,
+										"character": 187
+									}
+								}
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 202,
+							"end": 209,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 215,
+				"end": 217,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 217,
+				"end": 275,
+				"data": " Trailing line comment on a self-closing component "
+			},
+			{
+				"type": "Text",
+				"start": 275,
+				"end": 276,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "Component",
+				"start": 276,
+				"end": 309,
+				"name": "Comp",
+				"name_loc": {
+					"start": {
+						"line": 16,
+						"column": 1,
+						"character": 277
+					},
+					"end": {
+						"line": 16,
+						"column": 5,
+						"character": 281
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 283,
+						"end": 294,
+						"name": "prop",
+						"name_loc": {
+							"start": {
+								"line": 17,
+								"column": 1,
+								"character": 283
+							},
+							"end": {
+								"line": 17,
+								"column": 5,
+								"character": 287
+							}
+						},
+						"value": {
+							"type": "ExpressionTag",
+							"start": 288,
+							"end": 294,
+							"expression": {
+								"type": "Identifier",
+								"start": 289,
+								"end": 293,
+								"loc": {
+									"start": {
+										"line": 17,
+										"column": 7
+									},
+									"end": {
+										"line": 17,
+										"column": 11
+									}
+								},
+								"name": "expr"
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 309,
+				"end": 311,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 311,
+				"end": 363,
+				"data": " Trailing line comment on a spread attribute "
+			},
+			{
+				"type": "Text",
+				"start": 363,
+				"end": 364,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 364,
+				"end": 406,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 21,
+						"column": 1,
+						"character": 365
+					},
+					"end": {
+						"line": 21,
+						"column": 4,
+						"character": 368
+					}
+				},
+				"attributes": [
+					{
+						"type": "SpreadAttribute",
+						"start": 370,
+						"end": 379,
+						"expression": {
+							"type": "Identifier",
+							"start": 374,
+							"end": 378,
+							"loc": {
+								"start": {
+									"line": 22,
+									"column": 5
+								},
+								"end": {
+									"line": 22,
+									"column": 9
+								}
+							},
+							"name": "expr"
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 393,
+							"end": 400,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 406,
+				"end": 408,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 408,
+				"end": 453,
+				"data": " Trailing line comment on a directive "
+			},
+			{
+				"type": "Text",
+				"start": 453,
+				"end": 454,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 454,
+				"end": 497,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 28,
+						"column": 1,
+						"character": 455
+					},
+					"end": {
+						"line": 28,
+						"column": 4,
+						"character": 458
+					}
+				},
+				"attributes": [
+					{
+						"start": 460,
+						"end": 470,
+						"type": "BindDirective",
+						"name": "value",
+						"name_loc": {
+							"start": {
+								"line": 29,
+								"column": 1,
+								"character": 460
+							},
+							"end": {
+								"line": 29,
+								"column": 11,
+								"character": 470
+							}
+						},
+						"expression": {
+							"start": 465,
+							"end": 470,
+							"type": "Identifier",
+							"name": "value"
+						},
+						"modifiers": []
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 484,
+							"end": 491,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 497,
+				"end": 499,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 499,
+				"end": 574,
+				"data": " Trailing block comment collapses inline (block is self-delimiting) "
+			},
+			{
+				"type": "Text",
+				"start": 574,
+				"end": 575,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 575,
+				"end": 618,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 35,
+						"column": 1,
+						"character": 576
+					},
+					"end": {
+						"line": 35,
+						"column": 4,
+						"character": 579
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 580,
+						"end": 597,
+						"name": "data-attr",
+						"name_loc": {
+							"start": {
+								"line": 35,
+								"column": 5,
+								"character": 580
+							},
+							"end": {
+								"line": 35,
+								"column": 14,
+								"character": 589
+							}
+						},
+						"value": [
+							{
+								"start": 591,
+								"end": 596,
+								"type": "Text",
+								"raw": "value",
+								"data": "value"
+							}
+						]
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 608,
+							"end": 612,
+							"raw": "text",
+							"data": "text"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 618,
+				"end": 620,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Comment",
+				"start": 620,
+				"end": 694,
+				"data": " Own-line and same-line comments coexist; each placement preserved "
+			},
+			{
+				"type": "Text",
+				"start": 694,
+				"end": 695,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 695,
+				"end": 753,
+				"name": "div",
+				"name_loc": {
+					"start": {
+						"line": 38,
+						"column": 1,
+						"character": 696
+					},
+					"end": {
+						"line": 38,
+						"column": 4,
+						"character": 699
+					}
+				},
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 709,
+						"end": 726,
+						"name": "data-attr",
+						"name_loc": {
+							"start": {
+								"line": 40,
+								"column": 1,
+								"character": 709
+							},
+							"end": {
+								"line": 40,
+								"column": 10,
+								"character": 718
+							}
+						},
+						"value": [
+							{
+								"start": 720,
+								"end": 725,
+								"type": "Text",
+								"raw": "value",
+								"data": "value"
+							}
+						]
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 740,
+							"end": 747,
+							"raw": "\n\ttext\n",
+							"data": "\n\ttext\n"
+						}
+					]
+				}
+			}
+		]
+	},
+	"options": null,
+	"comments": [
+		{
+			"type": "Line",
+			"start": 91,
+			"end": 102,
+			"value": " trailing",
+			"loc": {
+				"start": {
+					"line": 3,
+					"column": 19,
+					"character": 91
+				},
+				"end": {
+					"line": 3,
+					"column": 30,
+					"character": 102
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 189,
+			"end": 200,
+			"value": " trailing",
+			"loc": {
+				"start": {
+					"line": 10,
+					"column": 9,
+					"character": 189
+				},
+				"end": {
+					"line": 10,
+					"column": 20,
+					"character": 200
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 295,
+			"end": 306,
+			"value": " trailing",
+			"loc": {
+				"start": {
+					"line": 17,
+					"column": 13,
+					"character": 295
+				},
+				"end": {
+					"line": 17,
+					"column": 24,
+					"character": 306
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 380,
+			"end": 391,
+			"value": " trailing",
+			"loc": {
+				"start": {
+					"line": 22,
+					"column": 11,
+					"character": 380
+				},
+				"end": {
+					"line": 22,
+					"column": 22,
+					"character": 391
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 471,
+			"end": 482,
+			"value": " trailing",
+			"loc": {
+				"start": {
+					"line": 29,
+					"column": 12,
+					"character": 471
+				},
+				"end": {
+					"line": 29,
+					"column": 23,
+					"character": 482
+				}
+			}
+		},
+		{
+			"type": "Block",
+			"start": 598,
+			"end": 607,
+			"value": " bar ",
+			"loc": {
+				"start": {
+					"line": 35,
+					"column": 23,
+					"character": 598
+				},
+				"end": {
+					"line": 35,
+					"column": 32,
+					"character": 607
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 701,
+			"end": 707,
+			"value": " own",
+			"loc": {
+				"start": {
+					"line": 39,
+					"column": 1,
+					"character": 701
+				},
+				"end": {
+					"line": 39,
+					"column": 7,
+					"character": 707
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"start": 727,
+			"end": 738,
+			"value": " trailing",
+			"loc": {
+				"start": {
+					"line": 40,
+					"column": 19,
+					"character": 727
+				},
+				"end": {
+					"line": 40,
+					"column": 30,
+					"character": 738
+				}
+			}
+		}
+	]
+}

--- a/tests/fixtures/svelte/attributes/comment_trailing_same_line/input.svelte
+++ b/tests/fixtures/svelte/attributes/comment_trailing_same_line/input.svelte
@@ -1,0 +1,43 @@
+<!-- Trailing line comment on a regular attribute stays inline -->
+<div
+	data-attr="value" // trailing
+>
+	text
+</div>
+
+<!-- Trailing line comment on a shorthand attribute -->
+<div
+	{value} // trailing
+>
+	text
+</div>
+
+<!-- Trailing line comment on a self-closing component -->
+<Comp
+	prop={expr} // trailing
+/>
+
+<!-- Trailing line comment on a spread attribute -->
+<div
+	{...expr} // trailing
+>
+	text
+</div>
+
+<!-- Trailing line comment on a directive -->
+<div
+	bind:value // trailing
+>
+	text
+</div>
+
+<!-- Trailing block comment collapses inline (block is self-delimiting) -->
+<div data-attr="value" /* bar */>text</div>
+
+<!-- Own-line and same-line comments coexist; each placement preserved -->
+<div
+	// own
+	data-attr="value" // trailing
+>
+	text
+</div>

--- a/tests/fixtures/svelte/attributes/comment_trailing_same_line/unformatted_compact.svelte
+++ b/tests/fixtures/svelte/attributes/comment_trailing_same_line/unformatted_compact.svelte
@@ -1,0 +1,43 @@
+<!-- Trailing line comment on a regular attribute stays inline -->
+<div
+data-attr="value"// trailing
+>
+text
+</div>
+
+<!-- Trailing line comment on a shorthand attribute -->
+<div
+{value}// trailing
+>
+text
+</div>
+
+<!-- Trailing line comment on a self-closing component -->
+<Comp
+prop={expr} // trailing
+/>
+
+<!-- Trailing line comment on a spread attribute -->
+<div
+{...expr}// trailing
+>
+text
+</div>
+
+<!-- Trailing line comment on a directive -->
+<div
+bind:value// trailing
+>
+text
+</div>
+
+<!-- Trailing block comment collapses inline (block is self-delimiting) -->
+<div data-attr="value"/* bar */>text</div>
+
+<!-- Own-line and same-line comments coexist; each placement preserved -->
+<div
+// own
+data-attr="value"// trailing
+>
+text
+</div>


### PR DESCRIPTION
Diverges from prettier-plugin-svelte by retaining comment position instead of forced wrapping in attributes.