### PR TITLE
docs: use Prettier camelCase option names for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 High-performance Rust parser as a drop-in replacement for Svelte's modern parser (acorn + acorn-typescript) with a near-Prettier formatter that tracks Prettier closely.
 
-**Non-configurable by design**: formatting options are fixed at Prettier's defaults except print_width=100, use_tabs=true, and bracketSpacing=false — no config files, CLI flags, or runtime options, ever (opinionated like `gofmt` and Black). See [Configuration](#configuration).
+**Non-configurable by design**: formatting options are fixed at Prettier's defaults except printWidth=100, useTabs=true, singleQuote=true, and bracketSpacing=false — no config files, CLI flags, or runtime options, ever (opinionated like `gofmt` and Black). See [Configuration](#configuration).
 
 ## Committing
 
@@ -314,15 +314,18 @@ See ./docs/performance.md.
 
 **Non-configurable by design.** Formatting options are fixed at Prettier's defaults, except where noted below, and cannot be changed — there are no config files, CLI flags, or runtime options, and none are planned. tsv is opinionated like `gofmt` and Black: one canonical style, always. A narrower user-facing option set may be revisited far down the road, but the 0.x contract is no configuration at all.
 
-The table lists the settings that diverge from Prettier's defaults; everything else (e.g. tab_width=2) matches Prettier.
+The table lists the settings that diverge from Prettier's defaults; everything else (e.g. tabWidth=2) matches Prettier.
 
 | Setting          | Value | Notes                                       |
 | ---------------- | ----- | ------------------------------------------- |
-| `print_width`    | 100   | Wider than Prettier's default of 80         |
-| `use_tabs`       | true  | Tabs, not spaces (Prettier defaults to off) |
-| `bracketSpacing` | false | No spaces inside `{ }` — discussion welcome |
+| `printWidth`     | 100   | Wider than Prettier's default of 80         |
+| `useTabs`        | true  | Tabs, not spaces (Prettier defaults to off) |
+| `singleQuote`    | true  | Single quotes, not double (Prettier off)    |
+| `bracketSpacing` | false | No spaces inside `{ }`                      |
 
-**Measuring line widths**: Use `cargo run -p tsv_debug line_width <file>` to measure visual width of lines (accounts for tab_width=2). Never use `wc -c` — it counts bytes, not visual characters (tabs are 1 byte but 2 visual chars). The `compare` command also shows line widths on changed lines.
+`bracketSpacing: false`: tight object and destructuring braces (`{foo}`) stay visually distinct from the `{` that opens a function body or block.
+
+**Measuring line widths**: Use `cargo run -p tsv_debug line_width <file>` to measure visual width of lines (accounts for tabWidth=2). Never use `wc -c` — it counts bytes, not visual characters (tabs are 1 byte but 2 visual chars). The `compare` command also shows line widths on changed lines.
 
 ### Internal Configuration (Rust Library Only)
 
@@ -506,7 +509,7 @@ cargo run -p tsv_debug check                  # Verify sidecar works
 # compare - diff our formatter vs prettier (shows line widths on changed lines)
 cargo run -p tsv_debug compare file.svelte
 # Options: --verbose/-v (full input/ours/prettier), --quiet, --color <auto|always|never>, --json
-# Line widths appear as right-aligned numbers on diff lines (helps spot print_width issues)
+# Line widths appear as right-aligned numbers on diff lines (helps spot printWidth issues)
 # "Outputs match" = ours(input) == prettier(input), NOT input stability; a match on a
 # non-format-stable input adds a note + input-vs-formatted diff (F1 fails on such an input)
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ from anything that speaks C FFI. Deno's FFI is used in the benchmarks.
   (see [docs/conformance_svelte.md](docs/conformance_svelte.md)),
   but keeps its own internal AST optimized for manipulation over serialization
 - non-configurable: formatter settings are fixed at Prettier's defaults except
-  `print_width: 100`, `use_tabs: true`, and
-  `bracketSpacing: false` (maybe controversial, discussion welcome),
+  `printWidth: 100`, `useTabs: true`, `singleQuote: true`, and
+  `bracketSpacing: false` (tight object braces stay distinct from function/block `{`),
   and there are no config files or CLI config options -
   tsv is opinionated like `gofmt` and Python's Black,
   see [CLAUDE.md § Configuration](CLAUDE.md#configuration)

--- a/crates/tsv_wasm/README_all.md
+++ b/crates/tsv_wasm/README_all.md
@@ -36,7 +36,7 @@ Three formatters (`format_svelte`, `format_typescript`, `format_css`) take a sou
 
 AST types are bundled in `tsv_ast.d.ts` and re-exported from the package — `import type` any node directly.
 
-tsv is non-configurable: formatter settings are fixed at Prettier's defaults (`print_width: 100`, `tab_width: 2`, `use_tabs: true`) — no options, like `gofmt` and Black.
+tsv is non-configurable: formatter settings are fixed at Prettier's defaults except `printWidth: 100`, `useTabs: true`, `singleQuote: true`, and `bracketSpacing: false` — no options, like `gofmt` and Black.
 
 ## Status
 

--- a/crates/tsv_wasm/README_format.md
+++ b/crates/tsv_wasm/README_format.md
@@ -41,7 +41,7 @@ const formatted = format_svelte('<script>\nconst   x=1\n</script>');
 
 `init_sync({ module })` is also exported for Workers and custom loading.
 
-tsv is non-configurable: settings are fixed at Prettier's defaults (`print_width: 100`, `tab_width: 2`, `use_tabs: true`) — no options, like `gofmt` and Black.
+tsv is non-configurable: settings are fixed at Prettier's defaults except `printWidth: 100`, `useTabs: true`, `singleQuote: true`, and `bracketSpacing: false` — no options, like `gofmt` and Black.
 
 ## Status
 

--- a/docs/conformance_prettier.md
+++ b/docs/conformance_prettier.md
@@ -89,7 +89,7 @@ as `tabs + 2 spaces`. The result mixes tabs and spaces on a single indentation
 level.
 
 tsv rounds the 2-column offset up to one tab everywhere. At
-`tab_width = 2` the two are the same visual width; only the representation
+`tabWidth = 2` the two are the same visual width; only the representation
 differs (`⟨n+1 tabs⟩}` vs `⟨n tabs⟩··}`). This keeps indentation
 tab-width-agnostic: a reader viewing tabs at any width sees consistent
 structure, whereas Prettier's 2-space offset assumes the prefix is exactly 2
@@ -142,7 +142,7 @@ columns wide. Cataloged in [Tabs-Only Alignment](#tabs-only-alignment).
 
 **Space-separated value wrap**: Prettier doesn't wrap CSS space-separated values (e.g., `box-shadow`) when they exceed print width. A 101-char `box-shadow: var(--a) color-mix(...)` stays on one line. tsv wraps at the print width boundary, breaking between space-separated values. This respects the configured print width rather than allowing arbitrary overflows.
 
-**Comma+space value boundary**: When comma-separated values contain space-separated parts (like multiple `box-shadow` values), Prettier tolerates lines exceeding print_width. tsv breaks to stay within 100 chars. See `comma_space_separated_long/` for the matching behavior at 100 and 102 chars.
+**Comma+space value boundary**: When comma-separated values contain space-separated parts (like multiple `box-shadow` values), Prettier tolerates lines exceeding printWidth. tsv breaks to stay within 100 chars. See `comma_space_separated_long/` for the matching behavior at 100 and 102 chars.
 
 **Number dot-ident**: tsv matches Prettier's number normalization for all valid CSS — scientific-notation exponents (`1E+2`→`1e2`, `5e0`→`5`), trailing/leading zeros (`1.50`→`1.5`, `.5`→`0.5`), and a trailing dot before a terminator (`1.`→`1`, `1.e1`→`1e1`). This applies to declaration values and to `@media`/`@supports` preludes; `@container` preludes are left raw, matching Prettier. The lone divergence is the _invalid_ sequence `<number>.<ident>` (e.g. `1.px`, `1.foo`): Prettier merges it into a dimension (`1px`), but per CSS Syntax 3 §4.3.3 that is three tokens (`<number>` `<delim .>` `<ident>`), not a dimension — so tsv preserves the source verbatim. This only arises in invalid CSS; Prettier itself keeps `url(1.png)` unmerged.
 

--- a/docs/fixture_overview.md
+++ b/docs/fixture_overview.md
@@ -598,25 +598,25 @@ cargo run -p tsv_debug line_width tests/fixtures/css/values/functions/gradient_l
 
 # Output shows:
 # Line 1: 7 chars (0 tabs = 0, content = 7) ✓
-# Line 4: 101 chars (3 tabs = 6, content = 95) ✗ EXCEEDS print_width (100)
-# Line 5: 100 chars (3 tabs = 6, content = 94) ⚠️ EXACTLY print_width (100)
+# Line 4: 101 chars (3 tabs = 6, content = 95) ✗ EXCEEDS printWidth (100)
+# Line 5: 100 chars (3 tabs = 6, content = 94) ⚠️ EXACTLY printWidth (100)
 # ...
-# Summary: 3/35 lines exceed print_width (100)
+# Summary: 3/35 lines exceed printWidth (100)
 ```
 
 **Measure specific line:**
 
 ```bash
 cargo run -p tsv_debug line_width input.svelte --line 4
-# Line 4: 101 chars (3 tabs = 6, content = 95) ✗ EXCEEDS print_width (100)
+# Line 4: 101 chars (3 tabs = 6, content = 95) ✗ EXCEEDS printWidth (100)
 #   			clip-path: polygon(...);
 ```
 
 **Tab width calculation:**
 
-- Each `\t` counts as `tab_width` chars (default: 2, matching prettier's `tabWidth: 2`)
+- Each `\t` counts as `tabWidth` chars (default: 2, matching prettier's `tabWidth: 2`)
 - **Indentation tabs DO count** toward line length (matches prettier's behavior)
-- Total = (tab_count × tab_width) + content_length
+- Total = (tab_count × tabWidth) + content_length
 
 **Boundary testing for `long` fixtures:**
 

--- a/tests/fixtures/css/at_rules/container_long_prettier_divergence/README.md
+++ b/tests/fixtures/css/at_rules/container_long_prettier_divergence/README.md
@@ -14,4 +14,4 @@ Prettier has stable variants: the inline form, the wrapped form, and a spaces-pr
 
 ## Reason
 
-tsv enforces print_width consistently across all CSS at-rules. Prettier simply never implemented wrapping for `@container` queries.
+tsv enforces printWidth consistently across all CSS at-rules. Prettier simply never implemented wrapping for `@container` queries.

--- a/tests/fixtures/css/at_rules/media_long_prettier_divergence/README.md
+++ b/tests/fixtures/css/at_rules/media_long_prettier_divergence/README.md
@@ -16,4 +16,4 @@ This applies only to a single query. A **comma-separated** query list is broken 
 
 ## Reason
 
-tsv enforces print_width consistently across all CSS at-rules. Prettier never implemented intra-query (`and`/`or`) wrapping for `@media`.
+tsv enforces printWidth consistently across all CSS at-rules. Prettier never implemented intra-query (`and`/`or`) wrapping for `@media`.

--- a/tests/fixtures/css/comma_separated_greedy_fill_prettier_divergence/README.md
+++ b/tests/fixtures/css/comma_separated_greedy_fill_prettier_divergence/README.md
@@ -1,6 +1,6 @@
 # comma_separated_greedy_fill_prettier_divergence
 
-Prettier's `fill()` allows comma-separated CSS values to exceed print_width by 1 char when trailing punctuation (`;`) is added after greedy packing.
+Prettier's `fill()` allows comma-separated CSS values to exceed printWidth by 1 char when trailing punctuation (`;`) is added after greedy packing.
 
 tsv: wraps before exceeding 100 chars
 Prettier: allows 101 chars (greedy fill + trailing `;`)
@@ -9,4 +9,4 @@ The root cause is Prettier's `fill()` packing to exactly the remaining width (`>
 
 ## Reason
 
-tsv treats print_width as a hard limit. This affects all comma-separated CSS values (`animation-name`, `font-family`, `background-image`, etc.).
+tsv treats printWidth as a hard limit. This affects all comma-separated CSS values (`animation-name`, `font-family`, `background-image`, etc.).

--- a/tests/fixtures/css/tokens/comments/media_long_prettier_divergence/README.md
+++ b/tests/fixtures/css/tokens/comments/media_long_prettier_divergence/README.md
@@ -9,4 +9,4 @@ Both formatters preserve comments in their original positions. The difference is
 
 ## Reason
 
-tsv enforces print_width consistently. See [media_long](../../../at_rules/media_long_prettier_divergence/) for the base case.
+tsv enforces printWidth consistently. See [media_long](../../../at_rules/media_long_prettier_divergence/) for the base case.

--- a/tests/fixtures/css/values/functions/transform_long_prettier_divergence/README.md
+++ b/tests/fixtures/css/values/functions/transform_long_prettier_divergence/README.md
@@ -1,6 +1,6 @@
 # transform_long_prettier_divergence
 
-Prettier doesn't wrap space-separated CSS value lists at the print_width boundary.
+Prettier doesn't wrap space-separated CSS value lists at the printWidth boundary.
 
 tsv: wraps at 101 chars (>100)
 Prettier: wraps at 102 chars (off-by-one)

--- a/tests/fixtures/css/values/lists/comma_space_separated_long_prettier_divergence/README.md
+++ b/tests/fixtures/css/values/lists/comma_space_separated_long_prettier_divergence/README.md
@@ -3,11 +3,11 @@
 At 101 chars, Prettier tolerates the overage and keeps space-separated values inline. tsv breaks to stay within 100 chars.
 
 tsv: wraps space-separated values within comma-separated list items
-Prettier: allows 101 char lines (1 over print_width)
+Prettier: allows 101 char lines (1 over printWidth)
 
 ## Reason
 
-tsv treats print_width as a hard limit. At 100 and 102 chars both formatters match — this divergence only manifests at the 101-char boundary.
+tsv treats printWidth as a hard limit. At 100 and 102 chars both formatters match — this divergence only manifests at the 101-char boundary.
 
 ## Related
 

--- a/tests/fixtures/css/values/lists/space_separated_long_wrap_prettier_divergence/README.md
+++ b/tests/fixtures/css/values/lists/space_separated_long_wrap_prettier_divergence/README.md
@@ -1,13 +1,13 @@
 # space_separated_long_wrap_prettier_divergence
 
-When a CSS space-separated value exceeds print_width, Prettier keeps it on one line. tsv wraps.
+When a CSS space-separated value exceeds printWidth, Prettier keeps it on one line. tsv wraps.
 
-tsv: wraps to respect print_width
-Prettier: allows lines to exceed print_width (101+ chars)
+tsv: wraps to respect printWidth
+Prettier: allows lines to exceed printWidth (101+ chars)
 
 ## Reason
 
-tsv treats print_width as a hard limit. This appears to be a limitation in prettier-plugin-svelte's CSS handling rather than an intentional design choice.
+tsv treats printWidth as a hard limit. This appears to be a limitation in prettier-plugin-svelte's CSS handling rather than an intentional design choice.
 
 ## Related
 

--- a/tests/fixtures/svelte/attributes/multiline_value_inline_long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/attributes/multiline_value_inline_long_prettier_divergence/README.md
@@ -1,12 +1,12 @@
 # multiline_value_inline_long_prettier_divergence
 
-When an inline element has breaking attributes (multiline value) and long trailing text follows, Prettier allows the line to exceed print_width (102 chars). tsv's fill breaks trailing words at the boundary.
+When an inline element has breaking attributes (multiline value) and long trailing text follows, Prettier allows the line to exceed printWidth (102 chars). tsv's fill breaks trailing words at the boundary.
 
 tsv: wraps last word to stay within 100 chars
 Prettier: keeps trailing text on one line (102 chars)
 
 ## Reason
 
-Prettier's `handleTextChild` early-returns for the last text child without wrapping the previous inline element. When the element has breaking attrs, there's no break point between the closing tag and trailing text, so the line exceeds print_width. tsv skips the wrapping too (matching Prettier), but the fill within the last text node still breaks at word boundaries.
+Prettier's `handleTextChild` early-returns for the last text child without wrapping the previous inline element. When the element has breaking attrs, there's no break point between the closing tag and trailing text, so the line exceeds printWidth. tsv skips the wrapping too (matching Prettier), but the fill within the last text node still breaks at word boundaries.
 
 See also `multiline_value_inline/` which shows both formatters match when trailing text is short.

--- a/tests/fixtures/svelte/blocks/await/long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/blocks/await/long_prettier_divergence/README.md
@@ -1,9 +1,9 @@
 # long_prettier_divergence
 
-Prettier keeps long expressions inline in `{#await}` blocks even when they exceed print_width.
+Prettier keeps long expressions inline in `{#await}` blocks even when they exceed printWidth.
 
 tsv: wraps expressions at 101+ chars
-Prettier: keeps inline (exceeds print_width)
+Prettier: keeps inline (exceeds printWidth)
 
 | Line width | tsv   | Prettier |
 | ---------- | ----- | -------- |

--- a/tests/fixtures/svelte/blocks/each/long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/blocks/each/long_prettier_divergence/README.md
@@ -1,9 +1,9 @@
 # long_prettier_divergence
 
-Prettier keeps long expressions inline in `{#each}` blocks even when they exceed print_width.
+Prettier keeps long expressions inline in `{#each}` blocks even when they exceed printWidth.
 
 tsv: wraps expressions at 101+ chars
-Prettier: keeps inline (exceeds print_width)
+Prettier: keeps inline (exceeds printWidth)
 
 | Line width | tsv   | Prettier |
 | ---------- | ----- | -------- |

--- a/tests/fixtures/svelte/blocks/if/in_inline_element_long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/blocks/if/in_inline_element_long_prettier_divergence/README.md
@@ -1,10 +1,10 @@
 # in_inline_element_long_prettier_divergence
 
-Prettier tolerates exceeding print_width (103 chars) for short comparison expressions in block conditions like `{#if typeof x === 'string'}` inside inline elements.
+Prettier tolerates exceeding printWidth (103 chars) for short comparison expressions in block conditions like `{#if typeof x === 'string'}` inside inline elements.
 
 tsv: breaks the expression to stay under 100 chars
 Prettier: keeps on one line at 103 chars
 
 ## Reason
 
-tsv respects the configured print_width. Prettier's tolerance for slight overruns with short binary expressions is a quirk, not a spec requirement.
+tsv respects the configured printWidth. Prettier's tolerance for slight overruns with short binary expressions is a quirk, not a spec requirement.

--- a/tests/fixtures/svelte/blocks/if/long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/blocks/if/long_prettier_divergence/README.md
@@ -1,9 +1,9 @@
 # long_prettier_divergence
 
-Prettier keeps long binary expressions inline in `{#if}` block conditions even when they exceed print_width.
+Prettier keeps long binary expressions inline in `{#if}` block conditions even when they exceed printWidth.
 
 tsv: wraps with continuation indent at 101+ chars
-Prettier: keeps inline (exceeds print_width)
+Prettier: keeps inline (exceeds printWidth)
 
 | Line width | tsv   | Prettier |
 | ---------- | ----- | -------- |

--- a/tests/fixtures/svelte/blocks/key/long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/blocks/key/long_prettier_divergence/README.md
@@ -1,9 +1,9 @@
 # long_prettier_divergence
 
-Prettier keeps long expressions inline in `{#key}` blocks even when they exceed print_width.
+Prettier keeps long expressions inline in `{#key}` blocks even when they exceed printWidth.
 
 tsv: wraps expressions at 101+ chars
-Prettier: keeps inline (exceeds print_width)
+Prettier: keeps inline (exceeds printWidth)
 
 | Line width | tsv   | Prettier |
 | ---------- | ----- | -------- |

--- a/tests/fixtures/svelte/elements/block_multiline_attrs_content_hug_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/elements/block_multiline_attrs_content_hug_prettier_divergence/README.md
@@ -1,9 +1,9 @@
 # block_multiline_attrs_content_hug_prettier_divergence
 
-When a whitespace-sensitive element (`<pre>`, `<textarea>`) has multiline attributes and hugged content exceeding print_width, Prettier keeps `>{content}</tag>` on the attribute line. tsv breaks `>` to its own line.
+When a whitespace-sensitive element (`<pre>`, `<textarea>`) has multiline attributes and hugged content exceeding printWidth, Prettier keeps `>{content}</tag>` on the attribute line. tsv breaks `>` to its own line.
 
-tsv: `\n>{content}</tag>` (respects print_width)
-Prettier: `">{content}</tag>` on attribute line (exceeds print_width)
+tsv: `\n>{content}</tag>` (respects printWidth)
+Prettier: `">{content}</tag>` on attribute line (exceeds printWidth)
 
 | Line width | tsv                    | Prettier             |
 | ---------- | ---------------------- | -------------------- |
@@ -14,4 +14,4 @@ The `>` immediately precedes `{expr}` with no whitespace, so no whitespace text 
 
 ## Reason
 
-tsv respects print_width while maintaining whitespace semantics. See `block_multiline_attrs_content_hug/` for the matching 100-char case.
+tsv respects printWidth while maintaining whitespace semantics. See `block_multiline_attrs_content_hug/` for the matching 100-char case.

--- a/tests/fixtures/svelte/elements/fill_after_inline_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/elements/fill_after_inline_prettier_divergence/README.md
@@ -1,10 +1,10 @@
 # fill_after_inline_prettier_divergence
 
-Prettier's `fill()` allows lines to exceed print_width when text follows an inline element closing tag (111 chars in this case, 11 over).
+Prettier's `fill()` allows lines to exceed printWidth when text follows an inline element closing tag (111 chars in this case, 11 over).
 
 tsv: breaks at exactly 100 chars
 Prettier: packs trailing text onto the line (111 chars)
 
 ## Reason
 
-tsv treats print_width as a hard limit. Prettier's fill algorithm doesn't account for the accumulated width when packing text after inline element wrappers.
+tsv treats printWidth as a hard limit. Prettier's fill algorithm doesn't account for the accumulated width when packing text after inline element wrappers.

--- a/tests/fixtures/svelte/elements/fill_multiple_expr_long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/elements/fill_multiple_expr_long_prettier_divergence/README.md
@@ -1,10 +1,10 @@
 # fill_multiple_expr_long_prettier_divergence
 
-When fill content with multiple expression tags exceeds print_width, Prettier breaks the opening bracket while tsv keeps the bracket hugging and breaks ternary expressions instead.
+When fill content with multiple expression tags exceeds printWidth, Prettier breaks the opening bracket while tsv keeps the bracket hugging and breaks ternary expressions instead.
 
 tsv: `<small>{expr} text{expr !== 1\n\t? 's'\n\t: ''}` (max 79 chars)
 Prettier: `<small\n\t>{expr} text{expr !== 1 ? 's' : ''}` (101 chars, exceeds)
 
 ## Reason
 
-tsv treats print_width as a hard limit. Breaking ternaries at `?` is more readable than breaking at `!==`, and keeping `<tag>{content}` on one line provides cleaner structure.
+tsv treats printWidth as a hard limit. Breaking ternaries at `?` is more readable than breaking at `!==`, and keeping `<tag>{content}` on one line provides cleaner structure.

--- a/tests/fixtures/svelte/elements/inline_component_fill_long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/elements/inline_component_fill_long_prettier_divergence/README.md
@@ -3,10 +3,10 @@
 Same fill boundary behavior as `inline_element_fill_long`, but with a component element (`<Comp>`) instead of an HTML inline element (`<a>`). At 101 chars, Prettier keeps everything on one line while tsv breaks the closing `>`.
 
 tsv: breaks to stay within 100 chars
-Prettier: allows 101 chars (1 over print_width)
+Prettier: allows 101 chars (1 over printWidth)
 
 At 100 chars both formatters match.
 
 ## Reason
 
-tsv treats print_width as a hard limit.
+tsv treats printWidth as a hard limit.

--- a/tests/fixtures/svelte/elements/inline_content_hug_long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/elements/inline_content_hug_long_prettier_divergence/README.md
@@ -1,6 +1,6 @@
 # inline_content_hug_long_prettier_divergence
 
-When inline element content with expressions exceeds print_width, there are two strategies:
+When inline element content with expressions exceeds printWidth, there are two strategies:
 
 1. Break opening bracket: `<small\n\t>content</small\n>` (Prettier)
 2. Break expression internally: `<small>{expr\n\t? x\n\t: y}</small\n>` (tsv)

--- a/tests/fixtures/svelte/elements/inline_element_fill_long_prettier_divergence/README.md
+++ b/tests/fixtures/svelte/elements/inline_element_fill_long_prettier_divergence/README.md
@@ -2,11 +2,11 @@
 
 At the fill boundary with an inline element, Prettier allows 101 chars (1 over) while tsv breaks one word earlier (94 chars).
 
-tsv: breaks at 94 chars (strict print_width)
+tsv: breaks at 94 chars (strict printWidth)
 Prettier: allows 101 chars (emergent from `group([line, element])` wrappers)
 
 At 100 chars both formatters match — see `inline_element_fill_100/`.
 
 ## Reason
 
-prettier-plugin-svelte structures docs with separate fills per text node and `group([line, element])` wrappers around inline elements. This creates an emergent behavior where lines can exceed print_width by 1 char. tsv's fill strictly respects print_width=100.
+prettier-plugin-svelte structures docs with separate fills per text node and `group([line, element])` wrappers around inline elements. This creates an emergent behavior where lines can exceed printWidth by 1 char. tsv's fill strictly respects printWidth=100.

--- a/tests/fixtures/typescript/declarations/function/return_type_generic_union_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/declarations/function/return_type_generic_union_long_prettier_divergence/README.md
@@ -1,14 +1,14 @@
 # return_type_generic_union_long_prettier_divergence
 
-Prettier has inconsistent special-casing for `null` and `void` in union types within generic return types at the print_width boundary.
+Prettier has inconsistent special-casing for `null` and `void` in union types within generic return types at the printWidth boundary.
 
 tsv: breaks consistently at 101+ chars inside the return type generic
-Prettier: function declarations and class methods exceed print_width; arrow functions use assignment break instead
+Prettier: function declarations and class methods exceed printWidth; arrow functions use assignment break instead
 
 Prettier's behavior varies by declaration kind:
-- Function declarations with `null`/`void`: allows line to exceed print_width
+- Function declarations with `null`/`void`: allows line to exceed printWidth
 - Arrow functions with `null`/`void`: breaks at `=` instead of in the return type
-- Class methods with `null`/`void`: allows line to exceed print_width
+- Class methods with `null`/`void`: allows line to exceed printWidth
 
 ## Reason
 

--- a/tests/fixtures/typescript/expressions/literals/template/interpolation_expression_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/expressions/literals/template/interpolation_expression_long_prettier_divergence/README.md
@@ -1,10 +1,10 @@
 # interpolation_expression_long_prettier_divergence
 
-When a template literal interpolation `${...}` contains a long expression exceeding print_width, Prettier keeps it inline. tsv breaks after `${` and puts `}` on its own line.
+When a template literal interpolation `${...}` contains a long expression exceeding printWidth, Prettier keeps it inline. tsv breaks after `${` and puts `}` on its own line.
 
-tsv: `${\n\tobj.aaa.bbb.ccc...\n}` (respects print_width)
-Prettier: `${obj.aaa.bbb.ccc...}` (exceeds print_width)
+tsv: `${\n\tobj.aaa.bbb.ccc...\n}` (respects printWidth)
+Prettier: `${obj.aaa.bbb.ccc...}` (exceeds printWidth)
 
 ## Reason
 
-tsv treats print_width as a hard limit for template interpolations. Consistent with tsv's template literal handling across all contexts.
+tsv treats printWidth as a hard limit for template interpolations. Consistent with tsv's template literal handling across all contexts.

--- a/tests/fixtures/typescript/expressions/literals/template/interpolation_multiline_indent_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/expressions/literals/template/interpolation_multiline_indent_long_prettier_divergence/README.md
@@ -1,6 +1,6 @@
 # interpolation_multiline_indent_long_prettier_divergence
 
-When template literal interpolations exceed print_width inside code-generation templates, tsv respects indentation using Prettier's `addAlignmentToDoc` approach: measure visual width of whitespace after the last `\n` in the quasi text before `${`, then position the expression at that absolute indent level.
+When template literal interpolations exceed printWidth inside code-generation templates, tsv respects indentation using Prettier's `addAlignmentToDoc` approach: measure visual width of whitespace after the last `\n` in the quasi text before `${`, then position the expression at that absolute indent level.
 
 tsv: breaks at `${`/`}` with proper visual alignment to quasi indentation
 Prettier: keeps `${identifier` on the same line, breaks chain at dots
@@ -11,4 +11,4 @@ Cases 1-15 test various indent sizes (tabs, spaces, mixed). Case 16 tests deeply
 
 ## Reason
 
-tsv treats print_width as a hard limit for template interpolations, with correct indentation alignment for multiline templates.
+tsv treats printWidth as a hard limit for template interpolations, with correct indentation alignment for multiline templates.

--- a/tests/fixtures/typescript/expressions/literals/template/interpolation_nested_template_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/expressions/literals/template/interpolation_nested_template_prettier_divergence/README.md
@@ -1,12 +1,12 @@
 # interpolation_nested_template_prettier_divergence
 
-When a template literal interpolation contains another template literal and exceeds print_width, Prettier keeps `${...}` inline. tsv breaks at `${`/`}` boundaries.
+When a template literal interpolation contains another template literal and exceeds printWidth, Prettier keeps `${...}` inline. tsv breaks at `${`/`}` boundaries.
 
-tsv: breaks at `${`/`}` when content exceeds print_width
-Prettier: keeps `${...}` inline (exceeds print_width)
+tsv: breaks at `${`/`}` when content exceeds printWidth
+Prettier: keeps `${...}` inline (exceeds printWidth)
 
 Tests various expression contexts: ternaries, logical operators, arrays, function calls, and arrow callbacks within nested templates.
 
 ## Reason
 
-tsv treats print_width as a hard limit for template interpolations. Consistent with tsv's template literal handling across all contexts.
+tsv treats printWidth as a hard limit for template interpolations. Consistent with tsv's template literal handling across all contexts.

--- a/tests/fixtures/typescript/expressions/literals/template/long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/expressions/literals/template/long_prettier_divergence/README.md
@@ -1,9 +1,9 @@
 # long_prettier_divergence
 
-Tests the 100/101 char print_width boundary for template literal interpolations.
+Tests the 100/101 char printWidth boundary for template literal interpolations.
 
 tsv: breaks to `${\n\texpr\n}` at 101 chars
-Prettier: keeps `${expr}` inline (exceeds print_width)
+Prettier: keeps `${expr}` inline (exceeds printWidth)
 
 | Line width | tsv                | Prettier           |
 | ---------- | ------------------ | ------------------ |
@@ -12,4 +12,4 @@ Prettier: keeps `${expr}` inline (exceeds print_width)
 
 ## Reason
 
-tsv treats print_width as a hard limit for template interpolations. Consistent with tsv's template literal handling across all contexts.
+tsv treats printWidth as a hard limit for template interpolations. Consistent with tsv's template literal handling across all contexts.

--- a/tests/fixtures/typescript/expressions/logical/template_operand_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/expressions/logical/template_operand_long_prettier_divergence/README.md
@@ -1,10 +1,10 @@
 # template_operand_long_prettier_divergence
 
-Prettier has two stable forms when a binary operator's template operand exceeds print_width: broken `${` (tsv's form) and inline `${expr}` (Prettier's quirk form). Both are idempotent under Prettier.
+Prettier has two stable forms when a binary operator's template operand exceeds printWidth: broken `${` (tsv's form) and inline `${expr}` (Prettier's quirk form). Both are idempotent under Prettier.
 
 tsv: breaks at `=`, `&&`, AND `${` — normalizes all inputs to broken form
 Prettier: breaks at `=` and `&&`, keeps template inline (101+ chars)
 
 ## Reason
 
-tsv breaks template interpolations to respect print_width. Consistent with tsv's template literal handling across all contexts.
+tsv breaks template interpolations to respect printWidth. Consistent with tsv's template literal handling across all contexts.

--- a/tests/fixtures/typescript/expressions/ternary/template_consequent_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/expressions/ternary/template_consequent_long_prettier_divergence/README.md
@@ -1,10 +1,10 @@
 # template_consequent_long_prettier_divergence
 
-Prettier has two stable forms when a ternary's template consequent exceeds print_width: broken `${` (tsv's form) and inline `${expr}` (Prettier's quirk form). Both are idempotent under Prettier.
+Prettier has two stable forms when a ternary's template consequent exceeds printWidth: broken `${` (tsv's form) and inline `${expr}` (Prettier's quirk form). Both are idempotent under Prettier.
 
 tsv: breaks at `?`, `:`, AND `${` — normalizes all inputs to broken form
 Prettier: breaks at `?` and `:`, keeps template inline (101+ chars)
 
 ## Reason
 
-tsv breaks template interpolations to respect print_width. Consistent with tsv's template literal handling across all contexts.
+tsv breaks template interpolations to respect printWidth. Consistent with tsv's template literal handling across all contexts.

--- a/tests/fixtures/typescript/modules/imports/path_calls_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/modules/imports/path_calls_long_prettier_divergence/README.md
@@ -3,7 +3,7 @@
 Prettier has special handling for module path calls that differs from tsv.
 
 **Plain `require()`:**
-tsv: wraps arguments at print_width (101+ chars)
+tsv: wraps arguments at printWidth (101+ chars)
 Prettier: never wraps plain `require(string)` calls
 
 **`require.resolve.paths()` and `import.meta.resolve()`:**
@@ -14,4 +14,4 @@ Matching patterns (both formatters agree): `require.resolve(string)` and `await 
 
 ## Reason
 
-tsv wraps consistently — lines should respect print_width, and function calls should wrap the same way regardless of the callee. Consistent with tsv's handling of single-specifier imports.
+tsv wraps consistently — lines should respect printWidth, and function calls should wrap the same way regardless of the callee. Consistent with tsv's handling of single-specifier imports.

--- a/tests/fixtures/typescript/modules/imports/single_specifier_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/modules/imports/single_specifier_long_prettier_divergence/README.md
@@ -1,10 +1,10 @@
 # single_specifier_long_prettier_divergence
 
-Prettier intentionally keeps single-specifier imports on one line even when they exceed print_width (decision from 2017: "you don't get much more information when they are in two lines").
+Prettier intentionally keeps single-specifier imports on one line even when they exceed printWidth (decision from 2017: "you don't get much more information when they are in two lines").
 
 tsv: wraps at 101+ chars
 Prettier: never wraps single-specifier imports
 
 ## Reason
 
-tsv wraps consistently — if print_width=100 is configured, lines should respect it. Multi-specifier imports already wrap at print_width. The original Prettier decision received 18 thumbs-down vs 0 thumbs-up. Tooling (code review, terminals, side-by-side diffs) relies on line width limits.
+tsv wraps consistently — if printWidth=100 is configured, lines should respect it. Multi-specifier imports already wrap at printWidth. The original Prettier decision received 18 thumbs-down vs 0 thumbs-up. Tooling (code review, terminals, side-by-side diffs) relies on line width limits.

--- a/tests/fixtures/typescript/types/comments/union_member_long_line_comment_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/comments/union_member_long_line_comment_prettier_divergence/README.md
@@ -9,7 +9,7 @@ exercised through the line-comment path instead of the main union path.
 tsv: closing `>` at a whole tab (`3 tabs`)
 Prettier: closing `>` at `2 tabs + 2 spaces`
 
-Both are the same visual width at `tab_width = 2`; only the representation
+Both are the same visual width at `tabWidth = 2`; only the representation
 differs. The inner row (`Inner<…>`) sits at `4 tabs` in both — the member's
 internal break is offset one level past the `| ` prefix regardless of the
 adjacent comment, matching how the main union path lays the same member out.

--- a/tests/fixtures/typescript/types/nested_generic_member_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/nested_generic_member_long_prettier_divergence/README.md
@@ -9,7 +9,7 @@ spaces` (a sub-tab alignment).
 tsv: closing `>` at a whole tab (`3 tabs`)
 Prettier: closing `>` at `2 tabs + 2 spaces`
 
-Both are the same visual width at `tab_width = 2`; only the representation
+Both are the same visual width at `tabWidth = 2`; only the representation
 differs (whole tabs vs tabs-then-spaces).
 
 ## Reason

--- a/tests/fixtures/typescript/types/template_literal_type_conditional_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/template_literal_type_conditional_long_prettier_divergence/README.md
@@ -1,6 +1,6 @@
 # template_literal_type_conditional_long_prettier_divergence
 
-When a conditional type inside a template literal type exceeds print_width, Prettier preserves whatever form is given (stable variant — both compact and broken are idempotent). tsv normalizes to break at `?` and `:` operators.
+When a conditional type inside a template literal type exceeds printWidth, Prettier preserves whatever form is given (stable variant — both compact and broken are idempotent). tsv normalizes to break at `?` and `:` operators.
 
 tsv: breaks at `?` and `:` at 101+ chars
 Prettier: preserves input form (stable variant, allows inline at 101+ chars)

--- a/tests/fixtures/typescript/types/template_literal_type_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/template_literal_type_long_prettier_divergence/README.md
@@ -1,9 +1,9 @@
 # template_literal_type_long_prettier_divergence
 
-When a template literal type exceeds print_width, both formatters break at `=` for type aliases. After the `=` break, Prettier keeps the template literal inline even if it still exceeds print_width. tsv also breaks at `${` if the line remains over 100 chars.
+When a template literal type exceeds printWidth, both formatters break at `=` for type aliases. After the `=` break, Prettier keeps the template literal inline even if it still exceeds printWidth. tsv also breaks at `${` if the line remains over 100 chars.
 
 tsv: breaks at `=` AND `${` when needed
-Prettier: breaks at `=` only, keeps template inline (exceeds print_width)
+Prettier: breaks at `=` only, keeps template inline (exceeds printWidth)
 
 Tests single interpolation, multiple interpolations (one long), and multiple interpolations (several long). Each `${...}` that exceeds 100 chars breaks independently.
 
@@ -11,7 +11,7 @@ See `template_literal_type_long/` for matching cases at the 100-char boundary.
 
 ## Reason
 
-tsv applies the same print_width rules after `=` breaks — consistent with template literal value handling.
+tsv applies the same printWidth rules after `=` breaks — consistent with template literal value handling.
 
 ## Related
 

--- a/tests/fixtures/typescript/types/union_fn_type_member_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/union_fn_type_member_long_prettier_divergence/README.md
@@ -9,7 +9,7 @@ alignment).
 tsv: closing `) => void)` at a whole tab
 Prettier: closing `) => void)` at `2 tabs + 2 spaces`
 
-Both are the same visual width at `tab_width = 2`; only the representation
+Both are the same visual width at `tabWidth = 2`; only the representation
 differs (whole tabs vs tabs-then-spaces).
 
 `Short` (inline) and `Fit` (params at exactly 100, stays inline) are the

--- a/tests/fixtures/typescript/types/union_hug_object_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/union_hug_object_prettier_divergence/README.md
@@ -8,7 +8,7 @@ with `--use-tabs` the object members land at whole tabs but the closing `}` at
 tsv: closing `}` at a whole tab
 Prettier: closing `}` at `2 tabs + 2 spaces`
 
-Both are the same visual width at `tab_width = 2`; only the representation
+Both are the same visual width at `tabWidth = 2`; only the representation
 differs (whole tabs vs tabs-then-spaces).
 
 ## Reason

--- a/tests/fixtures/typescript/types/union_intersection_object_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/union_intersection_object_long_prettier_divergence/README.md
@@ -9,7 +9,7 @@ object members land at whole tabs but the closing `})` at `2 tabs + 2 spaces`
 tsv: closing `})` at a whole tab
 Prettier: closing `})` at `2 tabs + 2 spaces`
 
-Both are the same visual width at `tab_width = 2`; only the representation
+Both are the same visual width at `tabWidth = 2`; only the representation
 differs (whole tabs vs tabs-then-spaces).
 
 ## Reason

--- a/tests/fixtures/typescript/types/union_object_member_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/union_object_member_prettier_divergence/README.md
@@ -8,7 +8,7 @@ the closing `}` at `2 tabs + 2 spaces` (a sub-tab alignment).
 tsv: closing `}` at a whole tab
 Prettier: closing `}` at `2 tabs + 2 spaces`
 
-Both are the same visual width at `tab_width = 2`; only the representation
+Both are the same visual width at `tabWidth = 2`; only the representation
 differs (whole tabs vs tabs-then-spaces).
 
 ## Reason

--- a/tests/fixtures/typescript/types/union_parens_object_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/union_parens_object_prettier_divergence/README.md
@@ -8,7 +8,7 @@ the closing `}` at `2 tabs + 2 spaces` (a sub-tab alignment).
 tsv: closing `}` at a whole tab
 Prettier: closing `}` at `2 tabs + 2 spaces`
 
-Both are the same visual width at `tab_width = 2`; only the representation
+Both are the same visual width at `tabWidth = 2`; only the representation
 differs (whole tabs vs tabs-then-spaces).
 
 ## Reason


### PR DESCRIPTION
tsv has no options any more, so this changes the obsolete snake_case refs to match Prettier's actual camelCase ones.