### PR TITLE
perf: memoize flat subtree widths for the arena_fits fast-path

### DIFF
--- a/crates/tsv_lang/src/doc/arena.rs
+++ b/crates/tsv_lang/src/doc/arena.rs
@@ -184,6 +184,22 @@ impl ArenaCommand {
     }
 }
 
+/// Sentinel cache values for the `arena_fits` flat-width fast-path. A cell holds
+/// either a real break-free flat width, or one of these two sentinels — the top
+/// two `u32` values, mirroring the `u16` text-width sentinels in `doc::types`
+/// (`TEXT_WIDTH_HAS_NEWLINE` / `TEXT_WIDTH_NOT_COMPUTED`). Packing the cache as
+/// `u32` (vs an 8-byte enum) halves its footprint — one `u32` per doc node, ~4
+/// nodes per source byte — which matters most for the memory-constrained WASM
+/// target.
+///
+/// A real width aliasing a sentinel would need a ~4 GB-wide break-free flat
+/// subtree, which is unreachable on real source; and even then it is
+/// correctness-safe, not wrong output — a `FLAT_WIDTH_BREAKS` alias just defers
+/// that node to the walk (which sums the same width), and a `FLAT_WIDTH_UNKNOWN`
+/// alias just recomputes it. So no cap on stored widths is needed.
+pub(super) const FLAT_WIDTH_UNKNOWN: u32 = u32::MAX;
+pub(super) const FLAT_WIDTH_BREAKS: u32 = u32::MAX - 1;
+
 /// Arena allocator for document nodes.
 ///
 /// All doc nodes are stored contiguously in `nodes`. Multi-child nodes
@@ -199,6 +215,10 @@ pub struct DocArena {
     /// match `nodes`; sound because nodes are append-only and the arena is
     /// per-format, so a node's `will_break` value never changes once it exists.
     will_break_cache: RefCell<Vec<Option<bool>>>,
+    /// Memoized flat-mode subtree widths for the `arena_fits` fast-path, indexed
+    /// by `DocId`. Lazily extended like `will_break_cache`; valid per-format
+    /// (depends only on `tab_width` + the interner, both fixed for a render).
+    flat_width_cache: RefCell<Vec<u32>>,
     /// Tab width for visual width calculations (stored for precomputing text widths)
     tab_width: usize,
 }
@@ -210,6 +230,7 @@ impl DocArena {
             nodes: RefCell::new(Vec::new()),
             children: RefCell::new(Vec::new()),
             will_break_cache: RefCell::new(Vec::new()),
+            flat_width_cache: RefCell::new(Vec::new()),
             tab_width,
         }
     }
@@ -224,6 +245,7 @@ impl DocArena {
             nodes: RefCell::new(Vec::with_capacity(estimated_nodes)),
             children: RefCell::new(Vec::with_capacity(estimated_children)),
             will_break_cache: RefCell::new(Vec::new()),
+            flat_width_cache: RefCell::new(Vec::new()),
             tab_width,
         }
     }
@@ -998,6 +1020,12 @@ impl DocArena {
     #[inline]
     pub fn borrow_children(&self) -> std::cell::Ref<'_, Vec<DocId>> {
         self.children.borrow()
+    }
+
+    /// Mutably borrow the flat-width cache for the `arena_fits` fast-path.
+    #[inline]
+    pub(super) fn borrow_flat_width_cache(&self) -> std::cell::RefMut<'_, Vec<u32>> {
+        self.flat_width_cache.borrow_mut()
     }
 
     /// Estimate output buffer capacity (bytes) for the rendered string.

--- a/crates/tsv_lang/src/doc/arena_fits.rs
+++ b/crates/tsv_lang/src/doc/arena_fits.rs
@@ -4,9 +4,100 @@ use crate::EmbedContext;
 use crate::printing::visual_width;
 use smallvec::SmallVec;
 
-use super::arena::{ArenaCommand, DocArena, DocId, DocNode};
+use super::arena::{ArenaCommand, DocArena, DocId, DocNode, FLAT_WIDTH_BREAKS, FLAT_WIDTH_UNKNOWN};
 use super::render_config::RenderConfig;
 use super::types::{LineKind, Mode, TEXT_WIDTH_HAS_NEWLINE, TextResolver, resolve_text};
+
+/// Flat-mode width of a subtree for the `arena_fits` fast-path, memoized per
+/// `DocId`. `Some(w)` = break-free subtree occupying `w` columns flat; `None` =
+/// contains a forced break, so `arena_fits` must walk it. Mirrors the flat-mode
+/// arm of the fits loop exactly, so substituting `remaining -= w` for the walk
+/// is byte-identical.
+fn flat_width_memo<R: TextResolver + ?Sized>(
+    id: DocId,
+    nodes: &[DocNode],
+    children: &[DocId],
+    cache: &mut [u32],
+    render: &RenderConfig,
+    resolver: Option<&R>,
+) -> Option<u32> {
+    match cache[id.index()] {
+        FLAT_WIDTH_UNKNOWN => {}
+        FLAT_WIDTH_BREAKS => return None,
+        w => return Some(w),
+    }
+    let result: Option<u32> = match &nodes[id.index()] {
+        DocNode::Text(t) => match t.cached_width() {
+            Some(w) if w == TEXT_WIDTH_HAS_NEWLINE => None,
+            Some(w) => Some(u32::from(w)),
+            None => {
+                let s = resolve_text(t, resolver);
+                if s.contains('\n') {
+                    None
+                } else {
+                    Some(visual_width(s, render.tab_width) as u32)
+                }
+            }
+        },
+        DocNode::Line(kind) => match kind {
+            LineKind::Hard | LineKind::Literal => None,
+            LineKind::Soft => Some(0),
+            LineKind::Normal => Some(1),
+        },
+        DocNode::Group {
+            contents,
+            should_break,
+            ..
+        } => {
+            if *should_break {
+                None
+            } else {
+                flat_width_memo(*contents, nodes, children, cache, render, resolver)
+            }
+        }
+        DocNode::IsolatedGroup { contents } => {
+            flat_width_memo(*contents, nodes, children, cache, render, resolver)
+        }
+        DocNode::Indent(inner) | DocNode::Dedent(inner) => {
+            flat_width_memo(*inner, nodes, children, cache, render, resolver)
+        }
+        DocNode::Align { contents, .. } => {
+            flat_width_memo(*contents, nodes, children, cache, render, resolver)
+        }
+        DocNode::IndentIfBreak { contents, .. } => {
+            flat_width_memo(*contents, nodes, children, cache, render, resolver)
+        }
+        DocNode::IfBreak { flat_doc, .. } => {
+            flat_width_memo(*flat_doc, nodes, children, cache, render, resolver)
+        }
+        DocNode::Concat(range) | DocNode::Fill(range) => {
+            let kids = range.resolve(children);
+            let mut sum: u32 = 0;
+            let mut ok = true;
+            for &kid in kids {
+                match flat_width_memo(kid, nodes, children, cache, render, resolver) {
+                    Some(w) => sum = sum.saturating_add(w),
+                    None => {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+            if ok { Some(sum) } else { None }
+        }
+        DocNode::WithContext { doc, context } => {
+            flat_width_memo(*doc, nodes, children, cache, render, resolver)
+                .map(|w| w.saturating_add(context.trailing_reserve as u32))
+        }
+        DocNode::LineSuffix(_) | DocNode::LineSuffixBoundary => Some(0),
+        DocNode::BreakParent => None,
+    };
+    cache[id.index()] = match result {
+        Some(w) => w,
+        None => FLAT_WIDTH_BREAKS,
+    };
+    result
+}
 
 /// Check if a doc fits in the remaining width, looking ahead at remaining commands.
 ///
@@ -32,6 +123,10 @@ pub(super) fn arena_fits_with_lookahead<R: TextResolver + ?Sized>(
 
     let nodes = arena.borrow_nodes();
     let children_vec = arena.borrow_children();
+    let mut flat_cache = arena.borrow_flat_width_cache();
+    if flat_cache.len() < nodes.len() {
+        flat_cache.resize(nodes.len(), FLAT_WIDTH_UNKNOWN);
+    }
     let mut remaining = remaining_width;
 
     let mut stack: SmallVec<[(DocId, Mode); 16]> = SmallVec::new();
@@ -49,6 +144,23 @@ pub(super) fn arena_fits_with_lookahead<R: TextResolver + ?Sized>(
             stack.push((cmd.doc, cmd.mode));
             continue;
         };
+
+        // Fast path: a break-free subtree in flat mode contributes a fixed,
+        // memoized width — identical to walking it (the walk would only sum the
+        // same width with no early return).
+        if current_mode == Mode::Flat
+            && let Some(w) = flat_width_memo(
+                current_id,
+                &nodes,
+                &children_vec,
+                flat_cache.as_mut_slice(),
+                render,
+                resolver,
+            )
+        {
+            remaining -= w as isize;
+            continue;
+        }
 
         match &nodes[current_id.index()] {
             DocNode::Text(t) => {

--- a/crates/tsv_lang/src/doc/mod.rs
+++ b/crates/tsv_lang/src/doc/mod.rs
@@ -743,4 +743,133 @@ mod arena_tests {
         assert_eq!(indent_str_width("  ", 2), 2);
         assert_eq!(indent_str_width("\t\t", 2), 4);
     }
+
+    // --- arena_fits flat-width fast-path guards ---
+    //
+    // `flat_width_memo` (arena_fits.rs) shortcuts break-free Flat subtrees with a
+    // memoized width instead of walking them. The fast path and the slow walk are
+    // two hand-maintained code paths that must stay byte-identical, so these tests
+    // pin each per-variant arm: a future desync (a miscounted width, or a Some/None
+    // that shortcuts a subtree that actually breaks) flips one of these assertions
+    // rather than silently producing wrong layout.
+
+    /// Fit `doc` in `width` columns in Flat mode, with no resolver (the docs here
+    /// use only `Static`/`Owned` text, never `Symbol`).
+    fn fits_flat(a: &DocArena, doc: DocId, width: usize) -> bool {
+        arena_fits(a, doc, width, Mode::Flat, None::<&dyn TextResolver>)
+    }
+
+    /// Assert the memoized flat width of `doc` is exactly `w`: it fits in `w` but
+    /// not in `w - 1`. Any off-by-N in a fast-path arm flips one of these.
+    fn assert_flat_width(a: &DocArena, doc: DocId, w: usize) {
+        assert!(fits_flat(a, doc, w), "expected width {w} to fit");
+        assert!(
+            !fits_flat(a, doc, w - 1),
+            "expected width {} not to fit",
+            w - 1
+        );
+    }
+
+    #[test]
+    fn test_fits_flat_width_concat_and_lines() {
+        let a = DocArena::new(2);
+        // concat sums child widths
+        assert_flat_width(&a, a.concat(&[a.text("abcd"), a.text("ef")]), 6);
+        // Normal line = 1 (space) in flat; Soft line = 0
+        assert_flat_width(&a, a.concat(&[a.text("ab"), a.line(), a.text("cd")]), 5);
+        assert_flat_width(&a, a.concat(&[a.text("ab"), a.softline(), a.text("cd")]), 4);
+        // fill is summed exactly like concat
+        assert_flat_width(&a, a.fill(&[a.text("ab"), a.line(), a.text("cd")]), 5);
+    }
+
+    #[test]
+    fn test_fits_flat_width_wrappers() {
+        let a = DocArena::new(2);
+        // a non-breaking group recurses into its contents
+        let g = a.group(a.concat(&[a.text("ab"), a.line(), a.text("cd")]));
+        assert_flat_width(&a, g, 5);
+        // isolated_group recurses too (this mirrors the fits walk, unlike will_break)
+        assert_flat_width(&a, a.isolated_group(a.text("abcde")), 5);
+        // indent / dedent / align add no width in flat mode (they matter only at breaks)
+        assert_flat_width(&a, a.indent(a.text("abc")), 3);
+        assert_flat_width(&a, a.dedent(a.text("abcd")), 4);
+        assert_flat_width(&a, a.align(4, a.text("ab")), 2);
+        // line_suffix content is deferred, so it contributes 0 to the fit width
+        let ls = a.concat(&[a.text("ab"), a.line_suffix(a.text("XXXXX")), a.text("cd")]);
+        assert_flat_width(&a, ls, 4);
+    }
+
+    #[test]
+    fn test_fits_flat_width_if_break_picks_flat_doc() {
+        let a = DocArena::new(2);
+        // In flat mode the flat_doc (", ", width 2) is measured, never break_doc (",\n").
+        let doc = a.concat(&[
+            a.text("("),
+            a.if_break(a.text(",\n"), a.text(", ")),
+            a.text(")"),
+        ]);
+        assert_flat_width(&a, doc, 4);
+    }
+
+    #[test]
+    fn test_fits_flat_width_with_context_trailing_reserve() {
+        let a = DocArena::new(2);
+        let doc = a.with_context(
+            a.text("abcd"),
+            DocContext {
+                trailing_reserve: 3,
+                base_indent_override: None,
+            },
+        );
+        // 4 content + 3 reserved = 7
+        assert_flat_width(&a, doc, 7);
+    }
+
+    #[test]
+    fn test_fits_flat_width_cached_non_ascii() {
+        let a = DocArena::new(2);
+        // "café" is non-ASCII, so its width is precomputed (cached_width = Some(4));
+        // this exercises the cached-`Some(w)` arm rather than the resolve fallback.
+        assert_flat_width(&a, a.text_owned("café".to_string()), 4);
+    }
+
+    #[test]
+    fn test_fits_flat_should_break_group_defers_to_walk() {
+        let a = DocArena::new(2);
+        // Flat content is 2+1+8 = 11 wide, but should_break forces Break mode in the
+        // walk, where the inner line returns "fits" early. The fast path must NOT
+        // shortcut this as an 11-wide flat subtree.
+        let content = a.concat(&[a.text("ab"), a.line(), a.text("cdefghij")]);
+        assert!(fits_flat(&a, a.group_break(content), 5));
+        // contrast: a non-breaking group with identical content does not fit at 5
+        let content2 = a.concat(&[a.text("ab"), a.line(), a.text("cdefghij")]);
+        assert!(!fits_flat(&a, a.group(content2), 5));
+    }
+
+    #[test]
+    fn test_fits_flat_hardline_defers_to_walk() {
+        let a = DocArena::new(2);
+        // hardline → the walk returns true after the leading text; a fast-path that
+        // miscounted the hardline as 0 would compute width 4 and wrongly fail at 3.
+        let doc = a.concat(&[a.text("ab"), a.hardline(), a.text("cd")]);
+        assert!(fits_flat(&a, doc, 3));
+    }
+
+    #[test]
+    fn test_fits_flat_break_parent_forces_false() {
+        let a = DocArena::new(2);
+        // BreakParent → the walk returns false even at unbounded width; a fast-path
+        // that treated it as 0 width would wrongly report "fits".
+        let doc = a.concat(&[a.text("ab"), a.break_parent(), a.text("cd")]);
+        assert!(!fits_flat(&a, doc, 100));
+    }
+
+    #[test]
+    fn test_fits_flat_newline_text_defers_to_walk() {
+        let a = DocArena::new(2);
+        // Static newline text: resolved on demand, contains '\n' → walk returns true.
+        assert!(fits_flat(&a, a.text("a\nb"), 0));
+        // Owned non-ASCII newline text: cached as HAS_NEWLINE → same early-true path.
+        assert!(fits_flat(&a, a.text_owned("café\nx".to_string()), 0));
+    }
 }


### PR DESCRIPTION
More follow-on perf work to #17 