### PR TITLE
fix: fix multibyte ts printing with template strings, diverging from prettier

### DIFF
--- a/crates/tsv_ts/src/printer/expressions/template_literal.rs
+++ b/crates/tsv_ts/src/printer/expressions/template_literal.rs
@@ -73,13 +73,9 @@ impl<'a> Printer<'a> {
                 let has_line_comment = leading_comments.iter().any(|c| !c.is_block)
                     || trailing_comments.iter().any(|c| !c.is_block);
 
-                // Build comment docs
-                let leading_comments_doc =
-                    self.build_template_interpolation_comments(&leading_comments, true);
-                let trailing_comments_doc =
-                    self.build_template_interpolation_comments(&trailing_comments, false);
-
-                // Combine expression with comments
+                // Combine expression with comments. The line-comment path builds its own
+                // layout (hardlines after `//`), so the plain leading/trailing docs are only
+                // built in the branch that uses them.
                 let full_expr_doc = if has_line_comment {
                     self.build_template_comments_and_expr_doc(
                         &leading_comments,
@@ -87,6 +83,10 @@ impl<'a> Printer<'a> {
                         &trailing_comments,
                     )
                 } else {
+                    let leading_comments_doc =
+                        self.build_template_interpolation_comments(&leading_comments, true);
+                    let trailing_comments_doc =
+                        self.build_template_interpolation_comments(&trailing_comments, false);
                     d.concat(&[leading_comments_doc, expr_doc, trailing_comments_doc])
                 };
 

--- a/crates/tsv_ts/src/printer/types/literal_types.rs
+++ b/crates/tsv_ts/src/printer/types/literal_types.rs
@@ -13,6 +13,27 @@ use tsv_lang::doc::arena::DocId;
 use tsv_lang::printing::visual_width;
 use tsv_lang::{PRINT_WIDTH, TAB_WIDTH};
 
+/// How a `${…}` interpolation in a template literal type breaks.
+///
+/// Decided in the first pass at flat-layout positions so the second pass can emit
+/// each interpolation with its break already chosen (see `build_template_literal_type_doc`).
+enum InterpolationLayout {
+    /// Conditional type: wrap in a group; breaks happen at the `?`/`:` operators.
+    Conditional,
+    /// Exceeds print width at its flat position — always break after `${`.
+    Forced,
+    /// Short enough — try the flat-rendered string first, break if it doesn't fit
+    /// at the actual render position.
+    Flex(String),
+}
+
+/// One `${…}` interpolation's docs plus its computed layout.
+struct Interpolation {
+    type_doc: DocId,
+    comments_doc: DocId,
+    layout: InterpolationLayout,
+}
+
 impl<'a> Printer<'a> {
     /// Build a Doc for a literal type
     pub(super) fn build_literal_type_doc(&self, lit: &TSLiteralType) -> DocId {
@@ -46,10 +67,8 @@ impl<'a> Printer<'a> {
     pub(super) fn build_template_literal_type_doc(&self, template: &TemplateLiteralType) -> DocId {
         let d = self.d();
 
-        // First pass: analyze types and determine which exceed print width at their flat positions
-        // Store as (doc, comments_doc, flat_str, is_conditional, exceeds_width)
-        let mut type_data: Vec<(DocId, DocId, String, bool, bool)> =
-            Vec::with_capacity(template.types.len());
+        // First pass: render each type flat and decide its break at its flat position.
+        let mut interps: Vec<Interpolation> = Vec::with_capacity(template.types.len());
         let mut pos: usize = 1; // Start after backtick
 
         for (i, quasi) in template.quasis.iter().enumerate() {
@@ -58,7 +77,6 @@ impl<'a> Printer<'a> {
             pos += visual_width(&quasi.raw, TAB_WIDTH);
             if i < template.types.len() {
                 let t = &template.types[i];
-                let is_conditional = matches!(t, TSType::Conditional(_));
                 // Comments between `${` and the type
                 // Find the `${` by searching backward from the type start
                 let search_start = quasi.span.start;
@@ -80,47 +98,51 @@ impl<'a> Printer<'a> {
                 // (comment width is small enough to ignore for width calculation)
                 // `${`/`}` are exact ASCII column counts; the type uses visual width.
                 let interp_end = pos + 2 + visual_width(&flat_str, TAB_WIDTH) + 1;
-                let exceeds_width = interp_end > PRINT_WIDTH;
+                pos = interp_end;
 
-                type_data.push((
+                let layout = if matches!(t, TSType::Conditional(_)) {
+                    InterpolationLayout::Conditional
+                } else if interp_end > PRINT_WIDTH {
+                    InterpolationLayout::Forced
+                } else {
+                    InterpolationLayout::Flex(flat_str)
+                };
+                interps.push(Interpolation {
                     type_doc,
                     comments_doc,
-                    flat_str,
-                    is_conditional,
-                    exceeds_width,
-                ));
-                pos = interp_end;
+                    layout,
+                });
             }
         }
 
-        // Second pass: build doc with breaking decisions already made
+        // Second pass: build doc with breaking decisions already made.
+        // indent() positions content relative to the template's current indent level
+        // (e.g. after an `=` break in a type alias): content gets +1, the closing `}`
+        // stays at the current level.
         let mut parts = vec![d.text("`")];
-        let mut type_iter = type_data.into_iter();
+        let mut interp_iter = interps.into_iter();
 
         for quasi in &template.quasis {
             parts.push(d.text_owned(quasi.raw.clone()));
-            if let Some((type_doc, comments_doc, flat_str, is_conditional, exceeds_width)) =
-                type_iter.next()
+            if let Some(Interpolation {
+                type_doc,
+                comments_doc,
+                layout,
+            }) = interp_iter.next()
             {
-                // Use relative indent() for positioning within the current context.
-                // The template is already at some indent level (e.g., after = break in type alias).
-                // Content gets +1 indent, closing stays at current level.
-                let interp_doc = if is_conditional {
-                    // Conditional types: wrap in group - breaks happen at ?/: operators
-                    // Don't add extra indent - conditional type's own formatting handles branch indentation
-                    d.concat(&[d.text("${"), comments_doc, d.group(type_doc), d.text("}")])
-                } else if exceeds_width {
-                    // Exceeds print width at flat position - always break
-                    d.concat(&[
+                let interp_doc = match layout {
+                    // Conditional type's own formatting handles branch indentation, so no extra indent.
+                    InterpolationLayout::Conditional => {
+                        d.concat(&[d.text("${"), comments_doc, d.group(type_doc), d.text("}")])
+                    }
+                    InterpolationLayout::Forced => d.concat(&[
                         d.text("${"),
                         comments_doc,
                         d.indent(d.concat(&[d.hardline(), type_doc])),
                         d.hardline(),
                         d.text("}"),
-                    ])
-                } else {
-                    // Short enough - try flat first, break if doesn't fit at actual position
-                    d.conditional_group(&[
+                    ]),
+                    InterpolationLayout::Flex(flat_str) => d.conditional_group(&[
                         d.concat(&[
                             d.text("${"),
                             comments_doc,
@@ -134,7 +156,7 @@ impl<'a> Printer<'a> {
                             d.line(),
                             d.text("}"),
                         ]),
-                    ])
+                    ]),
                 };
                 parts.push(interp_doc);
             }

--- a/crates/tsv_ts/src/printer/types/literal_types.rs
+++ b/crates/tsv_ts/src/printer/types/literal_types.rs
@@ -9,8 +9,9 @@
 
 use super::{CommentSpacing, Printer};
 use crate::ast::internal::{TSLiteralType, TSType, TemplateLiteralType};
-use tsv_lang::PRINT_WIDTH;
 use tsv_lang::doc::arena::DocId;
+use tsv_lang::printing::visual_width;
+use tsv_lang::{PRINT_WIDTH, TAB_WIDTH};
 
 impl<'a> Printer<'a> {
     /// Build a Doc for a literal type
@@ -52,7 +53,9 @@ impl<'a> Printer<'a> {
         let mut pos: usize = 1; // Start after backtick
 
         for (i, quasi) in template.quasis.iter().enumerate() {
-            pos += quasi.raw.len();
+            // Visual columns, not bytes: a CJK char is 3 bytes but 2 columns, so a
+            // byte sum would break a template whose rendered width is well under print width.
+            pos += visual_width(&quasi.raw, TAB_WIDTH);
             if i < template.types.len() {
                 let t = &template.types[i];
                 let is_conditional = matches!(t, TSType::Conditional(_));
@@ -75,7 +78,8 @@ impl<'a> Printer<'a> {
 
                 // Position includes: current pos + "${" (2) + type + "}" (1)
                 // (comment width is small enough to ignore for width calculation)
-                let interp_end = pos + 2 + flat_str.len() + 1;
+                // `${`/`}` are exact ASCII column counts; the type uses visual width.
+                let interp_end = pos + 2 + visual_width(&flat_str, TAB_WIDTH) + 1;
                 let exceeds_width = interp_end > PRINT_WIDTH;
 
                 type_data.push((

--- a/docs/conformance_prettier.md
+++ b/docs/conformance_prettier.md
@@ -333,6 +333,7 @@ Prettier uses atomic text (no doc structure) when the expression has no structur
 - Multiline indent — [interpolation_multiline_indent_long](../tests/fixtures/typescript/expressions/literals/template/interpolation_multiline_indent_long_prettier_divergence/)
 - Nested template — [interpolation_nested_template](../tests/fixtures/typescript/expressions/literals/template/interpolation_nested_template_prettier_divergence/)
 - Template literal type — [template_literal_type_long](../tests/fixtures/typescript/types/template_literal_type_long_prettier_divergence/)
+- Template literal type (multibyte width) — [template_literal_type_multibyte_long](../tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/)
 - Type with conditional — [template_literal_type_conditional_long](../tests/fixtures/typescript/types/template_literal_type_conditional_long_prettier_divergence/)
 - Ternary consequent — [template_consequent_long](../tests/fixtures/typescript/expressions/ternary/template_consequent_long_prettier_divergence/)
 - Binary operand — [template_operand_long](../tests/fixtures/typescript/expressions/logical/template_operand_long_prettier_divergence/)

--- a/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/README.md
+++ b/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/README.md
@@ -1,0 +1,21 @@
+# template_literal_type_multibyte_long_prettier_divergence
+
+Multibyte (CJK) companion to [template_literal_type_long](../template_literal_type_long_prettier_divergence/). The break-at-`${` decision for template literal types is a **visual-width** measure (CJK = 2 columns), not a byte count (CJK = 3 bytes), so a multibyte template type that fits within printWidth stays inline.
+
+When a template literal type exceeds printWidth, both formatters break at `=` for type aliases. After the `=` break, Prettier keeps the template inline even if it still exceeds printWidth. tsv also breaks at `${` once the line is over 100 visual columns.
+
+tsv: breaks at `=` AND `${` when the line exceeds 100 visual columns
+Prettier: breaks at `=` only, keeps template inline (exceeds printWidth)
+
+- `Inline` — multibyte quasi fits on one line (89 visual cols), both keep inline
+- `Fits` — after `=` break, continuation is exactly 100 visual cols, both keep inline
+- `Over` — after `=` break, continuation is 101 visual cols, Prettier inline, tsv breaks at `${`
+
+## Reason
+
+The threshold counts rendered columns, not source bytes: 33 CJK chars are 99 bytes but only 66 columns, so a byte-based threshold would break a template that visually fits. tsv applies the same printWidth rules after `=` breaks — consistent with template literal value handling.
+
+## Related
+
+- [template_literal_type_long](../template_literal_type_long_prettier_divergence/) — ASCII boundary cases (same divergence)
+- [template_literal_type_conditional_long](../template_literal_type_conditional_long_prettier_divergence/) — conditional types break at `?`/`:` instead of `${`

--- a/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/expected.json
+++ b/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/expected.json
@@ -1,0 +1,547 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 462,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": []
+	},
+	"options": null,
+	"comments": [
+		{
+			"type": "Line",
+			"value": " Multibyte quasi fits on one line - both formatters keep it inline",
+			"start": 20,
+			"end": 88,
+			"loc": {
+				"start": {
+					"line": 2,
+					"column": 1
+				},
+				"end": {
+					"line": 2,
+					"column": 69
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " After = break, continuation is 100 visual cols - both stay inline",
+			"start": 147,
+			"end": 215,
+			"loc": {
+				"start": {
+					"line": 5,
+					"column": 1
+				},
+				"end": {
+					"line": 5,
+					"column": 69
+				}
+			}
+		},
+		{
+			"type": "Line",
+			"value": " After = break, continuation is 101 visual cols - Prettier keeps inline, we break at ${",
+			"start": 286,
+			"end": 375,
+			"loc": {
+				"start": {
+					"line": 9,
+					"column": 1
+				},
+				"end": {
+					"line": 9,
+					"column": 90
+				}
+			}
+		}
+	],
+	"instance": {
+		"type": "Script",
+		"start": 0,
+		"end": 461,
+		"context": "default",
+		"content": {
+			"type": "Program",
+			"start": 18,
+			"end": 452,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 14,
+					"column": 9
+				}
+			},
+			"body": [
+				{
+					"type": "TSTypeAliasDeclaration",
+					"start": 90,
+					"end": 144,
+					"loc": {
+						"start": {
+							"line": 3,
+							"column": 1
+						},
+						"end": {
+							"line": 3,
+							"column": 55
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 95,
+						"end": 101,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 6
+							},
+							"end": {
+								"line": 3,
+								"column": 12
+							}
+						},
+						"name": "Inline"
+					},
+					"typeAnnotation": {
+						"type": "TSLiteralType",
+						"start": 104,
+						"end": 143,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 15
+							},
+							"end": {
+								"line": 3,
+								"column": 54
+							}
+						},
+						"literal": {
+							"type": "TemplateLiteral",
+							"start": 104,
+							"end": 143,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 15
+								},
+								"end": {
+									"line": 3,
+									"column": 54
+								}
+							},
+							"expressions": [
+								{
+									"type": "TSTypeReference",
+									"start": 140,
+									"end": 141,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 51
+										},
+										"end": {
+											"line": 3,
+											"column": 52
+										}
+									},
+									"typeName": {
+										"type": "Identifier",
+										"start": 140,
+										"end": 141,
+										"loc": {
+											"start": {
+												"line": 3,
+												"column": 51
+											},
+											"end": {
+												"line": 3,
+												"column": 52
+											}
+										},
+										"name": "T"
+									}
+								}
+							],
+							"quasis": [
+								{
+									"type": "TemplateElement",
+									"start": 105,
+									"end": 138,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 16
+										},
+										"end": {
+											"line": 3,
+											"column": 49
+										}
+									},
+									"value": {
+										"raw": "名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名",
+										"cooked": "名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名"
+									},
+									"tail": false
+								},
+								{
+									"type": "TemplateElement",
+									"start": 142,
+									"end": 142,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 53
+										},
+										"end": {
+											"line": 3,
+											"column": 53
+										}
+									},
+									"value": {
+										"raw": "",
+										"cooked": ""
+									},
+									"tail": true
+								}
+							]
+						}
+					},
+					"leadingComments": [
+						{
+							"type": "Line",
+							"value": " Multibyte quasi fits on one line - both formatters keep it inline",
+							"start": 20,
+							"end": 88
+						}
+					]
+				},
+				{
+					"type": "TSTypeAliasDeclaration",
+					"start": 217,
+					"end": 283,
+					"loc": {
+						"start": {
+							"line": 6,
+							"column": 1
+						},
+						"end": {
+							"line": 7,
+							"column": 54
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 222,
+						"end": 226,
+						"loc": {
+							"start": {
+								"line": 6,
+								"column": 6
+							},
+							"end": {
+								"line": 6,
+								"column": 10
+							}
+						},
+						"name": "Fits"
+					},
+					"typeAnnotation": {
+						"type": "TSLiteralType",
+						"start": 231,
+						"end": 282,
+						"loc": {
+							"start": {
+								"line": 7,
+								"column": 2
+							},
+							"end": {
+								"line": 7,
+								"column": 53
+							}
+						},
+						"literal": {
+							"type": "TemplateLiteral",
+							"start": 231,
+							"end": 282,
+							"loc": {
+								"start": {
+									"line": 7,
+									"column": 2
+								},
+								"end": {
+									"line": 7,
+									"column": 53
+								}
+							},
+							"expressions": [
+								{
+									"type": "TSTypeReference",
+									"start": 279,
+									"end": 280,
+									"loc": {
+										"start": {
+											"line": 7,
+											"column": 50
+										},
+										"end": {
+											"line": 7,
+											"column": 51
+										}
+									},
+									"typeName": {
+										"type": "Identifier",
+										"start": 279,
+										"end": 280,
+										"loc": {
+											"start": {
+												"line": 7,
+												"column": 50
+											},
+											"end": {
+												"line": 7,
+												"column": 51
+											}
+										},
+										"name": "T"
+									}
+								}
+							],
+							"quasis": [
+								{
+									"type": "TemplateElement",
+									"start": 232,
+									"end": 277,
+									"loc": {
+										"start": {
+											"line": 7,
+											"column": 3
+										},
+										"end": {
+											"line": 7,
+											"column": 48
+										}
+									},
+									"value": {
+										"raw": "名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名a",
+										"cooked": "名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名a"
+									},
+									"tail": false
+								},
+								{
+									"type": "TemplateElement",
+									"start": 281,
+									"end": 281,
+									"loc": {
+										"start": {
+											"line": 7,
+											"column": 52
+										},
+										"end": {
+											"line": 7,
+											"column": 52
+										}
+									},
+									"value": {
+										"raw": "",
+										"cooked": ""
+									},
+									"tail": true
+								}
+							]
+						}
+					},
+					"leadingComments": [
+						{
+							"type": "Line",
+							"value": " After = break, continuation is 100 visual cols - both stay inline",
+							"start": 147,
+							"end": 215
+						}
+					]
+				},
+				{
+					"type": "TSTypeAliasDeclaration",
+					"start": 377,
+					"end": 451,
+					"loc": {
+						"start": {
+							"line": 10,
+							"column": 1
+						},
+						"end": {
+							"line": 13,
+							"column": 5
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 382,
+						"end": 386,
+						"loc": {
+							"start": {
+								"line": 10,
+								"column": 6
+							},
+							"end": {
+								"line": 10,
+								"column": 10
+							}
+						},
+						"name": "Over"
+					},
+					"typeAnnotation": {
+						"type": "TSLiteralType",
+						"start": 391,
+						"end": 450,
+						"loc": {
+							"start": {
+								"line": 11,
+								"column": 2
+							},
+							"end": {
+								"line": 13,
+								"column": 4
+							}
+						},
+						"literal": {
+							"type": "TemplateLiteral",
+							"start": 391,
+							"end": 450,
+							"loc": {
+								"start": {
+									"line": 11,
+									"column": 2
+								},
+								"end": {
+									"line": 13,
+									"column": 4
+								}
+							},
+							"expressions": [
+								{
+									"type": "TSTypeReference",
+									"start": 444,
+									"end": 445,
+									"loc": {
+										"start": {
+											"line": 12,
+											"column": 3
+										},
+										"end": {
+											"line": 12,
+											"column": 4
+										}
+									},
+									"typeName": {
+										"type": "Identifier",
+										"start": 444,
+										"end": 445,
+										"loc": {
+											"start": {
+												"line": 12,
+												"column": 3
+											},
+											"end": {
+												"line": 12,
+												"column": 4
+											}
+										},
+										"name": "T"
+									}
+								}
+							],
+							"quasis": [
+								{
+									"type": "TemplateElement",
+									"start": 392,
+									"end": 438,
+									"loc": {
+										"start": {
+											"line": 11,
+											"column": 3
+										},
+										"end": {
+											"line": 11,
+											"column": 49
+										}
+									},
+									"value": {
+										"raw": "名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名aa",
+										"cooked": "名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名aa"
+									},
+									"tail": false
+								},
+								{
+									"type": "TemplateElement",
+									"start": 449,
+									"end": 449,
+									"loc": {
+										"start": {
+											"line": 13,
+											"column": 3
+										},
+										"end": {
+											"line": 13,
+											"column": 3
+										}
+									},
+									"value": {
+										"raw": "",
+										"cooked": ""
+									},
+									"tail": true
+								}
+							]
+						}
+					},
+					"leadingComments": [
+						{
+							"type": "Line",
+							"value": " After = break, continuation is 101 visual cols - Prettier keeps inline, we break at ${",
+							"start": 286,
+							"end": 375
+						}
+					]
+				}
+			],
+			"sourceType": "module"
+		},
+		"attributes": [
+			{
+				"type": "Attribute",
+				"start": 8,
+				"end": 17,
+				"name": "lang",
+				"name_loc": {
+					"start": {
+						"line": 1,
+						"column": 8,
+						"character": 8
+					},
+					"end": {
+						"line": 1,
+						"column": 12,
+						"character": 12
+					}
+				},
+				"value": [
+					{
+						"start": 14,
+						"end": 16,
+						"type": "Text",
+						"raw": "ts",
+						"data": "ts"
+					}
+				]
+			}
+		]
+	}
+}

--- a/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/input.svelte
+++ b/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/input.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	// Multibyte quasi fits on one line - both formatters keep it inline
+	type Inline = `名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名${T}`;
+
+	// After = break, continuation is 100 visual cols - both stay inline
+	type Fits =
+		`名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名a${T}`;
+
+	// After = break, continuation is 101 visual cols - Prettier keeps inline, we break at ${
+	type Over =
+		`名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名aa${
+			T
+		}`;
+</script>

--- a/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/output_prettier.svelte
+++ b/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/output_prettier.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	// Multibyte quasi fits on one line - both formatters keep it inline
+	type Inline = `名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名${T}`;
+
+	// After = break, continuation is 100 visual cols - both stay inline
+	type Fits =
+		`名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名a${T}`;
+
+	// After = break, continuation is 101 visual cols - Prettier keeps inline, we break at ${
+	type Over =
+		`名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名aa${T}`;
+</script>

--- a/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/unformatted_ours_compact.svelte
+++ b/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/unformatted_ours_compact.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	// Multibyte quasi fits on one line - both formatters keep it inline
+	type Inline = `名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名${T}`;
+
+	// After = break, continuation is 100 visual cols - both stay inline
+	type Fits = `名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名a${T}`;
+
+	// After = break, continuation is 101 visual cols - Prettier keeps inline, we break at ${
+	type Over = `名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名aa${T}`;
+</script>

--- a/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/unformatted_ours_spaces.svelte
+++ b/tests/fixtures/typescript/types/template_literal_type_multibyte_long_prettier_divergence/unformatted_ours_spaces.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+
+
+	// Multibyte quasi fits on one line - both formatters keep it inline
+	type Inline =
+		`名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名${T}`;
+
+
+
+	// After = break, continuation is 100 visual cols - both stay inline
+	type Fits =
+		`名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名a${
+			T
+		}`;
+
+
+	// After = break, continuation is 101 visual cols - Prettier keeps inline, we break at ${
+	type Over =
+		`名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名名aa${
+			T
+		}`;
+
+
+</script>


### PR DESCRIPTION
Template strings are one of the choices tsv makes to diverge from Prettier on, this is specifically for the multibyte character cases.