### PR TITLE
fix: parenthesized `in` expressions

### DIFF
--- a/crates/tsv_ts/src/parser/expression.rs
+++ b/crates/tsv_ts/src/parser/expression.rs
@@ -218,6 +218,24 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         result
     }
 
+    /// Run `f` with the `[In]` grammar parameter forced to `[+In]` (`allow_in =
+    /// true`), restoring the prior value afterward (even on error). Used at the
+    /// grammar productions that reset `[+In]` within a for-header init — the
+    /// ternary consequent, function/class bodies, param defaults — where a bare
+    /// `in` is the binary operator, not the for-in separator. A no-op outside a
+    /// for-header init (where `allow_in` is already `true`); a nested for-header
+    /// re-disables it via `parse_expression_no_in`'s own save/restore.
+    pub(super) fn with_allow_in<T>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<T, ParseError>,
+    ) -> Result<T, ParseError> {
+        let old_allow_in = self.allow_in;
+        self.allow_in = true;
+        let result = f(self);
+        self.allow_in = old_allow_in;
+        result
+    }
+
     /// Pratt parser: parse expression with minimum binding power
     ///
     /// Returns ParsedExpr with actual end position tracking for parentheses
@@ -374,7 +392,11 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         if min_bp <= BP_ASSIGNMENT && self.eat(TokenKind::Question) {
             // Parse consequent (then branch) - use BP_ASSIGNMENT to exclude comma operator
             // This ensures (a ? b : c, d) parses as ((a ? b : c), d) not (a ? b : (c, d))
-            let consequent = self.parse_expression_bp(BP_ASSIGNMENT)?;
+            // The consequent is `AssignmentExpression[+In]` — `in` is always the
+            // binary operator here, even inside a for-header init. The alternate
+            // is `[?In]` and inherits the outer context (so `for (a ? b : x in y;;)`
+            // still rejects).
+            let consequent = self.with_allow_in(|p| p.parse_expression_bp(BP_ASSIGNMENT))?;
 
             // Expect ':'
             self.expect(&TokenKind::Colon)?;
@@ -1800,6 +1822,11 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         // Dynamic import: import('module') or import('module', options)
         self.expect(&TokenKind::ParenOpen)?;
 
+        // The argument list is a grouping delimiter — `in` is always the binary
+        // operator inside it, even within a for-header init (the args are
+        // `AssignmentExpression[+In]`). Mirrors `parse_call_arguments`.
+        self.grouping_depth += 1;
+
         // Parse the source expression (usually a string literal)
         let source = self.parse_assignment_expression()?;
 
@@ -1821,6 +1848,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         // Capture end position before consuming ')'
         let (_, paren_end) = self.current_pos();
         self.expect(&TokenKind::ParenClose)?;
+        self.grouping_depth -= 1;
 
         Ok(Expression::ImportExpression(ImportExpression {
             source: arena.alloc(source),

--- a/crates/tsv_ts/src/parser/expression_arrow.rs
+++ b/crates/tsv_ts/src/parser/expression_arrow.rs
@@ -89,9 +89,13 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     /// Parse arrow function body: expression or block statement
     fn parse_arrow_body(&mut self) -> Result<ArrowFunctionBody<'arena>, ParseError> {
         if self.check(&TokenKind::BraceOpen) {
-            let block = self.parse_function_body()?;
+            // A block body is a `FunctionBody` (`[+In]`) — `in` is the binary
+            // operator even when this arrow sits in a for-header init.
+            let block = self.with_allow_in(Self::parse_function_body)?;
             Ok(ArrowFunctionBody::BlockStatement(block))
         } else {
+            // A concise body is `AssignmentExpression[?In]` — it inherits the
+            // outer In context, so `for (a = () => x in y;;)` still rejects.
             // Use assignment_expression so comma doesn't consume next object property
             let expr = self.parse_assignment_expression()?;
             Ok(ArrowFunctionBody::Expression(self.alloc(expr)))

--- a/crates/tsv_ts/src/parser/statement/class.rs
+++ b/crates/tsv_ts/src/parser/statement/class.rs
@@ -366,17 +366,23 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         let (start, _) = self.current_pos();
         self.expect(&TokenKind::BraceOpen)?;
 
-        let mut body = self.bvec();
-
-        while !matches!(self.current_kind(), TokenKind::BraceClose | TokenKind::Eof) {
-            // Stray semicolons are empty class members — acorn skips them,
-            // producing no node (prettier strips them on format).
-            if self.eat(TokenKind::Semicolon) {
-                continue;
+        // A class body is a fresh `[+In]` context: computed member names
+        // (`[+In]`), field initializers (`[+In]`), method/getter/setter bodies,
+        // and static blocks all permit `in` even when the class expression sits
+        // in a for-header init. A nested for-header inside re-disables it.
+        let body = self.with_allow_in(|p| {
+            let mut body = p.bvec();
+            while !matches!(p.current_kind(), TokenKind::BraceClose | TokenKind::Eof) {
+                // Stray semicolons are empty class members — acorn skips them,
+                // producing no node (prettier strips them on format).
+                if p.eat(TokenKind::Semicolon) {
+                    continue;
+                }
+                let member = p.parse_class_member(ambient)?;
+                body.push(member);
             }
-            let member = self.parse_class_member(ambient)?;
-            body.push(member);
-        }
+            Ok(body)
+        })?;
 
         let (_, end) = self.current_pos();
         self.expect(&TokenKind::BraceClose)?;

--- a/crates/tsv_ts/src/parser/statement/function.rs
+++ b/crates/tsv_ts/src/parser/statement/function.rs
@@ -311,14 +311,15 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         // Capture paren position before parsing params (for comment detection)
         let (params_start, _) = self.current_pos();
 
-        // Parse parameter list
-        let params: &'arena [Expression<'arena>] = self.parse_parameter_list()?.into_bump_slice();
-
-        // Check for return type annotation
-        let return_type = self.parse_optional_return_type()?;
-
-        // Parse function body
-        let body = self.parse_function_body()?;
+        // Param defaults (`[+In]`) and the function body are a fresh `[+In]`
+        // context, so `in` is the binary operator even when this function
+        // expression sits in a for-header init.
+        let (params, return_type, body) = self.with_allow_in(|p| {
+            let params: &'arena [Expression<'arena>] = p.parse_parameter_list()?.into_bump_slice();
+            let return_type = p.parse_optional_return_type()?;
+            let body = p.parse_function_body()?;
+            Ok((params, return_type, body))
+        })?;
         let end = body.span.end;
 
         Ok(Expression::FunctionExpression(FunctionExpression {

--- a/crates/tsv_ts/src/printer/calls/call_formatting.rs
+++ b/crates/tsv_ts/src/printer/calls/call_formatting.rs
@@ -3,7 +3,7 @@
 // Contains the primary `build_call_doc_with_wrapping` function that handles
 // all the special cases for call expression formatting.
 
-use super::super::{ParenContext, Printer, has_multiline_content, needs_parens};
+use super::super::{ParenContext, Printer, has_multiline_content};
 use super::arg_comments::{
     PartitionedComments, any_comment_forces_expansion, find_comma_pos, first_arg_has_any_comments,
     has_blank_line_between_args, has_inter_argument_comments, has_trailing_comments_on_args,
@@ -59,7 +59,7 @@ pub(super) fn build_call_doc_with_wrapping(
 
     // Wrap callee in parens if needed (e.g., ternary: `(a ? b : c)()`)
     // This must happen BEFORE adding removed-paren comments so comments stay outside
-    let callee_doc = if needs_parens(call.callee, ParenContext::Callee) {
+    let callee_doc = if printer.needs_parens(call.callee, ParenContext::Callee) {
         d.parens(callee_doc)
     } else {
         callee_doc

--- a/crates/tsv_ts/src/printer/calls/import_expr.rs
+++ b/crates/tsv_ts/src/printer/calls/import_expr.rs
@@ -56,7 +56,13 @@ pub(super) fn build_import_expression_doc(
     let open_paren_end = import_expr.span.start + "import(".len() as u32;
     let source_start = import_expr.source.span().start;
 
-    let raw_source_doc = printer.build_expression_doc(import_expr.source);
+    // Parenthesize an `in` argument inside a for-header init (`for (a = import(m,
+    // (b in c));…)`); a no-op elsewhere. Dynamic-import args are hand-rolled here
+    // rather than routed through `needs_parens(Argument)`, so apply the rule directly.
+    let raw_source_doc = printer.wrap_for_init_in(
+        import_expr.source,
+        printer.build_expression_doc(import_expr.source),
+    );
     let (source_doc, leading_forces_break) =
         printer.build_paren_leading_value_doc(open_paren_end, source_start, raw_source_doc);
 
@@ -104,7 +110,7 @@ pub(super) fn build_import_expression_doc(
         return wrap_import_group(d, source_doc);
     };
 
-    let options_doc = printer.build_expression_doc(options);
+    let options_doc = printer.wrap_for_init_in(options, printer.build_expression_doc(options));
     let options_end = options.span().end;
     let options_start = options.span().start;
 

--- a/crates/tsv_ts/src/printer/calls/new_expression.rs
+++ b/crates/tsv_ts/src/printer/calls/new_expression.rs
@@ -23,7 +23,7 @@ use crate::printer::calls::{
     should_force_expansion_for_comments, wrap_call_with_hard_breaks,
     wrap_call_with_will_break_guard,
 };
-use crate::printer::{ParenContext, Printer, has_multiline_content, needs_parens};
+use crate::printer::{ParenContext, Printer, has_multiline_content};
 use tsv_lang::doc::DocBuf;
 use tsv_lang::doc::arena::DocId;
 
@@ -41,7 +41,7 @@ impl<'a> Printer<'a> {
         // not stripped here even though the standalone path would).
         let callee = if let Some(sealed) = self.build_sealed_non_null_paren_doc(new_expr.callee) {
             sealed
-        } else if needs_parens(new_expr.callee, ParenContext::NewCallee) {
+        } else if self.needs_parens(new_expr.callee, ParenContext::NewCallee) {
             // For binary expressions (including logical), use a group with softlines
             // so the parens can break independently when the content is too long:
             // new (

--- a/crates/tsv_ts/src/printer/chain/analysis.rs
+++ b/crates/tsv_ts/src/printer/chain/analysis.rs
@@ -152,7 +152,9 @@ fn fix_callee_base_parens(nodes: &mut [ChainNode<'_>]) {
         if expr.has_optional_in_chain() {
             return;
         }
-        *np = needs_parens(expr, ParenContext::Callee);
+        // Callee always parenthesizes a binary operand for precedence, so the
+        // for-init `in` rule never changes the verdict here — pass `false`.
+        *np = needs_parens(expr, ParenContext::Callee, false);
     }
 }
 
@@ -250,7 +252,9 @@ fn linearize_recursive<'a>(
 
         // Base case: expression that's not part of the chain structure
         _ => {
-            let needs_parens = needs_parens(expr, ParenContext::ChainBase);
+            // ChainBase always parenthesizes a binary base for precedence, so
+            // the for-init `in` rule never changes the verdict here — pass `false`.
+            let needs_parens = needs_parens(expr, ParenContext::ChainBase, false);
             nodes.push(ChainNode::base(expr, needs_parens));
         }
     }

--- a/crates/tsv_ts/src/printer/class_common.rs
+++ b/crates/tsv_ts/src/printer/class_common.rs
@@ -188,7 +188,7 @@ impl<'a> Printer<'a> {
     /// arguments are rendered separately via `super_type_parameters`.
     fn build_super_class_doc(&self, super_class: &internal::Expression<'_>) -> DocId {
         let doc = self.build_expression_doc(super_class);
-        if super::needs_parens(super_class, super::ParenContext::SuperClass) {
+        if self.needs_parens(super_class, super::ParenContext::SuperClass) {
             self.d().parens(doc)
         } else {
             doc

--- a/crates/tsv_ts/src/printer/expressions/assignment.rs
+++ b/crates/tsv_ts/src/printer/expressions/assignment.rs
@@ -889,6 +889,10 @@ impl<'a> Printer<'a> {
                 self.build_expression_doc(right_expr)
             }
         });
+        // Parenthesize an `in` RHS inside a for-header init (`for (a = (b in c);…)`);
+        // a no-op elsewhere. The assignment builder is the RHS's only build site and
+        // never routes it through `needs_parens`, so the for-init rule is applied here.
+        let right_doc = self.wrap_for_init_in(right_expr, right_doc);
 
         // Validate static heuristic: if is_poorly_breakable_chain classified this
         // expression as poorly breakable (no good internal break points), the printed

--- a/crates/tsv_ts/src/printer/expressions/conditional.rs
+++ b/crates/tsv_ts/src/printer/expressions/conditional.rs
@@ -130,6 +130,9 @@ impl<'a> Printer<'a> {
         } else {
             test
         };
+        // Parenthesize an `in` test inside a for-header init (`for (a = (b in c) ? …;…)`);
+        // a no-op elsewhere. The test is `[~In]`, so the parens are load-bearing.
+        let test = self.wrap_for_init_in(cond.test, test);
         // Prettier's shouldNotIndent (binaryish.js:109-113) also applies to binaries
         // in consequent/alternate positions: when parent is ConditionalExpression and
         // grandparent is ReturnStatement/ThrowStatement/CallExpression/NewExpression,
@@ -297,6 +300,9 @@ impl<'a> Printer<'a> {
         } else {
             test
         };
+        // Parenthesize an `in` test inside a for-header init (`for (a = (b in c) ? …;…)`);
+        // a no-op elsewhere. The test is `[~In]`, so the parens are load-bearing.
+        let test = self.wrap_for_init_in(cond.test, test);
 
         // Find the ? and : positions for proper comment categorization
         let question_pos = self.find_char_outside_comments(test_end, consequent_start, b'?');
@@ -352,7 +358,13 @@ impl<'a> Printer<'a> {
                 let chained = self.build_conditional_doc_impl(nested, true, false);
                 (d.group_break(chained), true)
             } else {
-                (self.build_expression_doc(cond.consequent), false)
+                (
+                    self.wrap_for_init_in(
+                        cond.consequent,
+                        self.build_expression_doc(cond.consequent),
+                    ),
+                    false,
+                )
             };
         if has_line_comment_before_consequent {
             // Line comment — consequent on new line
@@ -410,14 +422,17 @@ impl<'a> Printer<'a> {
         }
 
         // Alternate expression - nested conditionals cascade the break without extra indent
-        let alternate_doc =
-            if let internal::Expression::ConditionalExpression(nested) = cond.alternate {
-                // Recursively use breaking layout - no indent wrapper (has its own structure)
-                self.build_conditional_doc_with_line_comments(nested, true)
-            } else {
-                // Regular expressions get indent wrapper
-                d.indent(self.build_expression_doc(cond.alternate))
-            };
+        let alternate_doc = if let internal::Expression::ConditionalExpression(nested) =
+            cond.alternate
+        {
+            // Recursively use breaking layout - no indent wrapper (has its own structure)
+            self.build_conditional_doc_with_line_comments(nested, true)
+        } else {
+            // Regular expressions get indent wrapper
+            d.indent(
+                self.wrap_for_init_in(cond.alternate, self.build_expression_doc(cond.alternate)),
+            )
+        };
 
         if has_line_comment_before_alternate {
             q_parts.push(d.hardline());
@@ -503,9 +518,14 @@ impl<'a> Printer<'a> {
         indent_binary: bool,
         boundary_end: u32,
     ) -> DocId {
-        if indent_binary && let internal::Expression::BinaryExpression(binary) = expr {
-            return self.build_binary_chain_doc_with_continuation_indent(binary);
-        }
-        self.build_expression_doc_with_paren_comments(expr, boundary_end)
+        let doc = if indent_binary && let internal::Expression::BinaryExpression(binary) = expr {
+            self.build_binary_chain_doc_with_continuation_indent(binary)
+        } else {
+            self.build_expression_doc_with_paren_comments(expr, boundary_end)
+        };
+        // Parenthesize an `in` consequent/alternate inside a for-header init
+        // (`for (a = c ? (b in c) : 0;…)`); a no-op elsewhere. Prettier wraps every
+        // `in` under the init; the alternate is `[~In]` so there it is load-bearing.
+        self.wrap_for_init_in(expr, doc)
     }
 }

--- a/crates/tsv_ts/src/printer/expressions/functions.rs
+++ b/crates/tsv_ts/src/printer/expressions/functions.rs
@@ -15,7 +15,7 @@ use crate::printer::types::helpers::is_huggable_type;
 use crate::printer::{CommentFilter, CommentSpacing};
 use crate::printer::{
     ParenContext, Printer, has_newline_before_position, is_multiline_template_expression,
-    needs_parens, unwrap_parenthesized,
+    unwrap_parenthesized,
 };
 use smallvec::smallvec;
 use tsv_lang::comments_in_range;
@@ -935,7 +935,7 @@ impl<'a> Printer<'a> {
         }
 
         // Standard cases: objects and assignments always need parens
-        if needs_parens(expr, ParenContext::ArrowBody) {
+        if self.needs_parens(expr, ParenContext::ArrowBody) {
             d.parens(self.build_expression_doc(expr))
         } else {
             self.build_expression_doc(expr)

--- a/crates/tsv_ts/src/printer/expressions/literals.rs
+++ b/crates/tsv_ts/src/printer/expressions/literals.rs
@@ -357,8 +357,7 @@ impl<'a> Printer<'a> {
         spread: &internal::SpreadElement<'_>,
     ) -> DocId {
         let d = self.d();
-        let needs_parens =
-            super::needs_parens(spread.argument, super::ParenContext::SpreadArgument);
+        let needs_parens = self.needs_parens(spread.argument, super::ParenContext::SpreadArgument);
         // A binaryish spread argument indents its continuation when it breaks
         // (`...(a &&\n\tb && {…})`), matching Prettier — a `SpreadElement` parent is
         // not in binaryish.js's `shouldNotIndent` set, so the logical/binary chain

--- a/crates/tsv_ts/src/printer/expressions/mod.rs
+++ b/crates/tsv_ts/src/printer/expressions/mod.rs
@@ -29,7 +29,7 @@ mod template_literal;
 
 use crate::ast::internal::{BinaryExpression, BinaryOperator, Expression, TSType};
 use crate::printer::comments::{CommentFilter, CommentSpacing};
-use crate::printer::{ParenContext, PatternContext, Printer, chain, needs_parens};
+use crate::printer::{ParenContext, PatternContext, Printer, chain};
 use smallvec::smallvec;
 use tsv_lang::doc::DocBuf;
 use tsv_lang::doc::arena::DocId;
@@ -247,7 +247,7 @@ impl<'a> Printer<'a> {
     pub(super) fn build_arg_expression_doc(&self, expr: &Expression<'_>) -> DocId {
         let d = self.d();
         // Assignment expressions need parens in argument context for clarity
-        if needs_parens(expr, ParenContext::Argument) {
+        if self.needs_parens(expr, ParenContext::Argument) {
             return d.parens(self.build_expression_doc(expr));
         }
 
@@ -292,7 +292,7 @@ impl<'a> Printer<'a> {
     ) -> DocId {
         let d = self.d();
         let expr_needs_parens =
-            needs_parens(type_assert.expression, ParenContext::AngleBracketAssertion);
+            self.needs_parens(type_assert.expression, ParenContext::AngleBracketAssertion);
         // Cast boundary positions: `<` … type … `>` … expression. The `>` is found
         // past any comment that itself contains a `>` (`<T /* > */>`).
         let open_pos = type_assert.span.start; // the `<`
@@ -469,7 +469,7 @@ impl<'a> Printer<'a> {
         is_as: bool,
     ) -> DocId {
         let d = self.d();
-        let needs_parens = needs_parens(expression, ParenContext::TypeAssertion);
+        let needs_parens = self.needs_parens(expression, ParenContext::TypeAssertion);
         let mut parts = DocBuf::new();
         if needs_parens {
             parts.push(d.text("("));
@@ -619,7 +619,7 @@ impl<'a> Printer<'a> {
         let d = self.d();
         let mut parts: DocBuf = DocBuf::new();
         let needs_parens =
-            needs_parens(inst_expr.expression, ParenContext::InstantiationExpression);
+            self.needs_parens(inst_expr.expression, ParenContext::InstantiationExpression);
         if needs_parens {
             parts.push(d.text("("));
         }
@@ -654,7 +654,7 @@ impl<'a> Printer<'a> {
         non_null_expr: &crate::ast::internal::TSNonNullExpression<'_>,
     ) -> DocId {
         let d = self.d();
-        let needs_parens = needs_parens(non_null_expr.expression, ParenContext::NonNull);
+        let needs_parens = self.needs_parens(non_null_expr.expression, ParenContext::NonNull);
 
         if needs_parens {
             // For expressions that need parens, use a special doc structure

--- a/crates/tsv_ts/src/printer/expressions/objects.rs
+++ b/crates/tsv_ts/src/printer/expressions/objects.rs
@@ -388,7 +388,7 @@ impl<'a> Printer<'a> {
         let key_doc = if prop.computed {
             // Assignment expressions need parens in computed keys: {[(a = b)]: c}
             let key_expr_doc =
-                if super::needs_parens(&prop.key, super::ParenContext::ComputedPropertyKey) {
+                if self.needs_parens(&prop.key, super::ParenContext::ComputedPropertyKey) {
                     d.parens(self.build_expression_doc(&prop.key))
                 } else {
                     self.build_expression_doc(&prop.key)
@@ -516,10 +516,9 @@ impl<'a> Printer<'a> {
             if self.has_line_comments_between(key_region_end, colon_pos) {
                 let value_doc = {
                     let v = self.build_expression_doc(&prop.value);
-                    let v = if super::needs_parens(
-                        &prop.value,
-                        super::ParenContext::ObjectPropertyValue,
-                    ) {
+                    let v = if self
+                        .needs_parens(&prop.value, super::ParenContext::ObjectPropertyValue)
+                    {
                         d.concat(&[d.text("("), v, d.text(")")])
                     } else {
                         v
@@ -542,7 +541,7 @@ impl<'a> Printer<'a> {
 
             // Check if value needs parens (e.g., assignment expressions)
             let needs_parens =
-                super::needs_parens(&prop.value, super::ParenContext::ObjectPropertyValue);
+                self.needs_parens(&prop.value, super::ParenContext::ObjectPropertyValue);
 
             if pre_colon_comments.is_empty() && post_colon_comments.is_empty() {
                 if needs_parens {

--- a/crates/tsv_ts/src/printer/expressions/operators.rs
+++ b/crates/tsv_ts/src/printer/expressions/operators.rs
@@ -6,7 +6,7 @@
 
 use crate::ast::internal::{self, BinaryOperator, Expression};
 use crate::printer::comments::CommentSpacing;
-use crate::printer::{ParenContext, Printer, needs_parens};
+use crate::printer::{ParenContext, Printer};
 use smallvec::{SmallVec, smallvec};
 use tsv_lang::Span;
 use tsv_lang::doc::{DocBuf, arena::DocId};
@@ -104,7 +104,7 @@ impl<'a> Printer<'a> {
         let argument_doc = if leading_comments_opt.is_some() || has_trailing_comments {
             // Comments inside grouping parens — must wrap in parens to preserve them.
             let inner = self.build_expression_doc(unary.argument);
-            let needs_paren_wrap = needs_parens(unary.argument, ParenContext::UnaryArgument);
+            let needs_paren_wrap = self.needs_parens(unary.argument, ParenContext::UnaryArgument);
             let inner = if needs_paren_wrap {
                 d.parens(inner)
             } else {
@@ -166,7 +166,7 @@ impl<'a> Printer<'a> {
                 parts.push(d.text(")"));
                 d.concat(&parts)
             }
-        } else if needs_parens(unary.argument, ParenContext::UnaryArgument) {
+        } else if self.needs_parens(unary.argument, ParenContext::UnaryArgument) {
             // Binary expressions need parens - use grouping for logical ops to allow line breaking
             if let Expression::BinaryExpression(binary) = unary.argument {
                 if binary.operator.is_logical() {
@@ -868,7 +868,7 @@ impl<'a> Printer<'a> {
         // - Embedded expression contexts (LayoutMode::Embedded): Use the grouped
         //   approach from build_binary_chain_doc_with_continuation_indent, which keeps
         //   short 2-operand binaries flat (Prettier's behavior for template expressions).
-        if needs_parens(operand, ctx) {
+        if self.needs_parens(operand, ctx) {
             if let Expression::BinaryExpression(inner_binary) = operand {
                 if self.embed.is_embedded() {
                     // Embedded expression context: use grouped approach that keeps short binaries flat
@@ -937,7 +937,7 @@ impl<'a> Printer<'a> {
             parts.push(inner);
             self.append_trailing_paren_comments(&mut parts, argument_end, await_expr.span.end);
             d.concat(&parts)
-        } else if needs_parens(await_expr.argument, ParenContext::AwaitArgument) {
+        } else if self.needs_parens(await_expr.argument, ParenContext::AwaitArgument) {
             d.concat(&[
                 d.text("("),
                 self.build_expression_doc(await_expr.argument),
@@ -988,7 +988,7 @@ impl<'a> Printer<'a> {
                 }
                 parts.push(self.build_expression_doc(arg));
                 self.append_trailing_paren_comments(&mut parts, argument_end, yield_expr.span.end);
-            } else if needs_parens(arg, ParenContext::YieldArgument) {
+            } else if self.needs_parens(arg, ParenContext::YieldArgument) {
                 // Assignment needs parens: `yield (x ??= y)`
                 parts.push(d.text("("));
                 parts.push(self.build_expression_doc(arg));

--- a/crates/tsv_ts/src/printer/expressions/patterns.rs
+++ b/crates/tsv_ts/src/printer/expressions/patterns.rs
@@ -9,9 +9,7 @@
 
 use crate::ast::internal::{self, ArrowFunctionBody, Expression, ObjectPatternProperty};
 use crate::printer::CommentSpacing;
-use crate::printer::{
-    ParenContext, PatternContext, Printer, needs_parens, object_pattern_should_expand,
-};
+use crate::printer::{ParenContext, PatternContext, Printer, object_pattern_should_expand};
 use smallvec::smallvec;
 use tsv_lang::comments_in_range;
 use tsv_lang::doc::DocBuf;
@@ -908,7 +906,7 @@ impl<'a> Printer<'a> {
         let inline_comments = self.build_rhs_comments_opt(eq_pos + 1, rhs_start);
 
         let rhs_doc = self.build_expression_doc(pattern.right);
-        let rhs_doc = if needs_parens(pattern.right, ParenContext::DefaultValue) {
+        let rhs_doc = if self.needs_parens(pattern.right, ParenContext::DefaultValue) {
             d.parens(rhs_doc)
         } else {
             rhs_doc

--- a/crates/tsv_ts/src/printer/expressions/template_literal.rs
+++ b/crates/tsv_ts/src/printer/expressions/template_literal.rs
@@ -5,7 +5,7 @@
 
 use crate::ast::internal::Expression;
 use crate::printer::comments::CommentSpacing;
-use crate::printer::{ParenContext, Printer, needs_parens};
+use crate::printer::{ParenContext, Printer};
 use tsv_lang::TAB_WIDTH;
 use tsv_lang::doc::arena::DocId;
 use tsv_lang::printing::visual_width;
@@ -52,7 +52,7 @@ impl<'a> Printer<'a> {
                 previous_quasi_indent_size = indent_size;
 
                 // Build expression doc
-                let expr_doc = if needs_parens(expr, ParenContext::TemplateLiteralExpression) {
+                let expr_doc = if self.needs_parens(expr, ParenContext::TemplateLiteralExpression) {
                     d.parens(self.build_expression_doc(expr))
                 } else {
                     self.build_expression_doc(expr)
@@ -335,7 +335,7 @@ impl<'a> Printer<'a> {
         // removed-paren comments so comments stay outside.
         let tag_doc = if let Some(sealed) = self.build_sealed_non_null_paren_doc(tagged.tag) {
             sealed
-        } else if needs_parens(tagged.tag, ParenContext::TaggedTemplateTag) {
+        } else if self.needs_parens(tagged.tag, ParenContext::TaggedTemplateTag) {
             d.parens(self.build_expression_doc(tagged.tag))
         } else {
             self.build_expression_doc(tagged.tag)

--- a/crates/tsv_ts/src/printer/mod.rs
+++ b/crates/tsv_ts/src/printer/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use expressions::assignment::{
     is_regex_root_chain, is_self_expanding_value, is_simple_self_expanding, is_simple_value,
     is_single_call_on_member_chain, is_type_assertion_call,
 };
-pub(crate) use needs_parens::{ParenContext, needs_parens};
+pub(crate) use needs_parens::{ParenContext, is_in_binary, needs_parens};
 pub(crate) use types::{should_hug_union_type, unwrap_parenthesized};
 
 use crate::PrinterInputs;
@@ -171,6 +171,16 @@ pub struct Printer<'a> {
     /// (`args.assignmentLayout`, `isCallLikeExpression(parent)`,
     /// `isBinaryish(parent)`) into `printArrowFunctionSignatures`.
     pub(crate) arrow_chain_context: Cell<ArrowChainContext>,
+    /// Whether we're building the **init** clause of a C-style `for` header.
+    /// In that clause an `in` binary expression must be parenthesized to keep it
+    /// distinct from the `for (x in y)` separator — prettier parenthesizes every
+    /// `in` anywhere lexically under the init (not just where strictly required),
+    /// so this flag is set while building the init subtree and propagates through
+    /// it (including nested function/class bodies). Read by `needs_parens` and the
+    /// surgical `in`-wrap at positions that build an expression without a
+    /// `needs_parens` check (assignment RHS, ternary branches/test).
+    /// Uses Cell for interior mutability so doc builders (&self) can set this.
+    pub(crate) in_for_init: Cell<bool>,
 }
 
 impl<'a> Printer<'a> {
@@ -205,7 +215,33 @@ impl<'a> Printer<'a> {
             arrow_body_object_parens_target: Cell::new(None),
             expr_stmt_paren_target: Cell::new(None),
             arrow_chain_context: Cell::new(ArrowChainContext::None),
+            in_for_init: Cell::new(false),
         }
+    }
+
+    /// Wrap `doc` in parens when `expr` is an `in` binary built directly inside a
+    /// `for` header init. Used at positions that build an expression *without* a
+    /// [`needs_parens`] check — assignment RHS, ternary branches/test, and the
+    /// init clause's own expression/declarator — so the for-init `in` rule still
+    /// applies there. Positions that already route through [`needs_parens`] (call
+    /// args, object values, binary operands, …) get the same wrap via that path.
+    #[inline]
+    pub(crate) fn wrap_for_init_in(&self, expr: &internal::Expression<'_>, doc: DocId) -> DocId {
+        if self.in_for_init.get() && is_in_binary(expr) {
+            self.arena.parens(doc)
+        } else {
+            doc
+        }
+    }
+
+    /// Print-context-aware wrapper over the free [`needs_parens`]: supplies the
+    /// ambient for-header-init flag so the for-init `in` rule applies at every
+    /// call site without threading the flag by hand. Prefer this inside `Printer`
+    /// methods; the free function (which still requires the flag explicitly) is
+    /// only for the few free helpers that have no `self`.
+    #[inline]
+    pub(crate) fn needs_parens(&self, expr: &internal::Expression<'_>, ctx: ParenContext) -> bool {
+        needs_parens(expr, ctx, self.in_for_init.get())
     }
 
     /// Get a reference to the doc arena.

--- a/crates/tsv_ts/src/printer/needs_parens.rs
+++ b/crates/tsv_ts/src/printer/needs_parens.rs
@@ -112,10 +112,32 @@ pub enum ParenContext {
     SuperClass,
 }
 
+/// Whether `expr` is an `in` binary expression — the operator that must be
+/// parenthesized inside a `for` header init so it isn't read as the `for (x in
+/// y)` separator. Shared by `needs_parens` (the ambient for-init rule) and the
+/// surgical `in`-wrap at positions that build an expression without a
+/// `needs_parens` check.
+pub(crate) fn is_in_binary(expr: &Expression<'_>) -> bool {
+    matches!(expr, Expression::BinaryExpression(b) if b.operator == BinaryOperator::In)
+}
+
 /// Determines if an expression needs parentheses in a given context.
 ///
 /// This is the central entry point for all parenthesization decisions.
-pub fn needs_parens(expr: &Expression<'_>, ctx: ParenContext) -> bool {
+///
+/// `in_for_init` is the ambient "building a `for` header init clause" flag: when
+/// set, an `in` binary expression always needs parens (prettier parenthesizes
+/// every `in` lexically under the init, regardless of context). It's threaded as
+/// a parameter rather than read from a context because parenthesization is a pure
+/// function of the node and its surroundings.
+pub fn needs_parens(expr: &Expression<'_>, ctx: ParenContext, in_for_init: bool) -> bool {
+    // Ambient for-init rule: an `in` binary always needs parens here. ORed ahead
+    // of the context match so it applies uniformly (call args, object values,
+    // binary operands, etc.) and never double-wraps a node a context already
+    // parenthesizes for precedence (`!(a in b)`, `(a in b).p`).
+    if in_for_init && is_in_binary(expr) {
+        return true;
+    }
     match ctx {
         // Assignment as value needs parens: `const x = (y = z);`
         ParenContext::VariableInit => matches!(expr, Expression::AssignmentExpression(_)),

--- a/crates/tsv_ts/src/printer/statements/class.rs
+++ b/crates/tsv_ts/src/printer/statements/class.rs
@@ -437,7 +437,11 @@ impl<'a> Printer<'a> {
             )
             .map_or(key_start, |p| p as u32);
             self.push_pre_name_comments_doc(&mut parts, cursor, bracket_pos);
-            let key_doc = self.build_expression_doc(&prop.key);
+            // Parenthesize an `in` computed key inside a for-header init
+            // (`for (C = class { [(b in c)]() {} };…)`); a no-op elsewhere. The
+            // object computed-key path applies this via `needs_parens`; class
+            // members build the key directly, so apply it here.
+            let key_doc = self.wrap_for_init_in(&prop.key, self.build_expression_doc(&prop.key));
             let (doc, end) = self.build_computed_key_bracket_doc(cursor, &prop.key, key_doc);
             key_region_end = end;
             parts.push(doc);
@@ -483,7 +487,7 @@ impl<'a> Printer<'a> {
             // relocation). Bypasses the assignment layout; value built lazily so the
             // common no-comment path is unaffected.
             let preserve = self.build_initializer_line_continuation(before_eq, eq_pos, || {
-                let value_doc = if super::needs_parens(value, super::ParenContext::DefaultValue) {
+                let value_doc = if self.needs_parens(value, super::ParenContext::DefaultValue) {
                     d.parens(self.build_expression_doc(value))
                 } else {
                     self.build_expression_doc(value)
@@ -524,7 +528,7 @@ impl<'a> Printer<'a> {
                     // built manually like object property values, since the layout
                     // chooser takes the bare expression
                     let assignment_doc =
-                        if super::needs_parens(value, super::ParenContext::DefaultValue) {
+                        if self.needs_parens(value, super::ParenContext::DefaultValue) {
                             let value_doc = d.parens(self.build_expression_doc(value));
                             let value_doc = match rhs_comments {
                                 Some(comments_doc) => d.concat(&[comments_doc, value_doc]),
@@ -638,7 +642,10 @@ impl<'a> Printer<'a> {
                 .map_or(key_start, |p| p as u32);
                 self.push_pre_name_comments_doc(&mut parts, cursor, bracket_pos);
             }
-            let key_doc = self.build_expression_doc(&method.key);
+            // Parenthesize an `in` computed key inside a for-header init (mirrors
+            // the object computed-key `needs_parens` wrap); a no-op elsewhere.
+            let key_doc =
+                self.wrap_for_init_in(&method.key, self.build_expression_doc(&method.key));
             let (doc, end) = self.build_computed_key_bracket_doc(cursor, &method.key, key_doc);
             key_region_end = end;
             parts.push(doc);

--- a/crates/tsv_ts/src/printer/statements/control_flow/loops/for_loop.rs
+++ b/crates/tsv_ts/src/printer/statements/control_flow/loops/for_loop.rs
@@ -1172,7 +1172,15 @@ impl<'a> Printer<'a> {
 
     fn build_for_init_doc(&self, init: &internal::ForInit<'_>) -> DocId {
         let d = self.d();
-        match init {
+        // The init clause is `[~In]`: an `in` binary must be parenthesized so it
+        // isn't read as the `for (x in y)` separator. Set for the whole init
+        // subtree (prettier parenthesizes every `in` lexically under the init,
+        // including inside nested function/class bodies); a nested for-header
+        // re-enables it for its own init. The `wrap_for_init_in` calls below cover
+        // the positions that build an expression without a `needs_parens` check;
+        // everything else routes through `needs_parens`, now flag-aware.
+        let saved_in_for_init = self.in_for_init.replace(true);
+        let result = match init {
             internal::ForInit::VariableDeclaration(decl) => {
                 let mut parts = vec![d.text(decl.kind.as_str()), d.text(" ")];
                 for (i, declarator) in decl.declarations.iter().enumerate() {
@@ -1189,7 +1197,7 @@ impl<'a> Printer<'a> {
                         {
                             parts.push(comments);
                         }
-                        parts.push(self.build_expression_doc(init));
+                        parts.push(self.wrap_for_init_in(init, self.build_expression_doc(init)));
                     }
                 }
                 d.concat(&parts)
@@ -1200,14 +1208,18 @@ impl<'a> Printer<'a> {
                 // Same handling as build_for_update_doc
                 if let Expression::SequenceExpression(seq) = expr {
                     d.join(
-                        seq.expressions.iter().map(|e| self.build_expression_doc(e)),
+                        seq.expressions
+                            .iter()
+                            .map(|e| self.wrap_for_init_in(e, self.build_expression_doc(e))),
                         ", ",
                     )
                 } else {
-                    self.build_expression_doc(expr)
+                    self.wrap_for_init_in(expr, self.build_expression_doc(expr))
                 }
             }
-        }
+        };
+        self.in_for_init.set(saved_in_for_init);
+        result
     }
 
     pub(in crate::printer::statements) fn build_for_in_statement_doc(

--- a/crates/tsv_ts/src/printer/statements/control_flow/mod.rs
+++ b/crates/tsv_ts/src/printer/statements/control_flow/mod.rs
@@ -483,7 +483,7 @@ impl<'a> Printer<'a> {
             }
             _ => self.build_expression_doc(expr),
         };
-        if super::needs_parens(expr, super::ParenContext::StatementTest) {
+        if self.needs_parens(expr, super::ParenContext::StatementTest) {
             let d = self.d();
             d.parens(inner)
         } else {

--- a/crates/tsv_ts/src/printer/statements/mod.rs
+++ b/crates/tsv_ts/src/printer/statements/mod.rs
@@ -18,9 +18,9 @@ mod variable;
 // Re-export for submodules to use `super::Printer` instead of `super::super::Printer`
 pub(super) use super::{Printer, build_entity_name_doc, should_hug_union_type};
 
+use super::ParenContext;
 use super::expressions::literals::format_directive;
 use super::needs_parens::leftmost_no_lookahead;
-use super::{ParenContext, needs_parens};
 use crate::ast::internal::{self, Expression, LiteralValue, Statement};
 use smallvec::smallvec;
 use tsv_lang::doc::DocBuf;
@@ -90,7 +90,8 @@ impl<'a> Printer<'a> {
         } else {
             // Parens required for correctness (object expressions, object pattern assignments)
             // OR preserved from source for string literals (matches Prettier behavior)
-            let needs_parens = needs_parens(&stmt.expression, ParenContext::ExpressionStatement)
+            let needs_parens = self
+                .needs_parens(&stmt.expression, ParenContext::ExpressionStatement)
                 || self.has_expression_statement_source_parens(stmt);
 
             if needs_parens {

--- a/crates/tsv_ts/src/printer/statements/variable.rs
+++ b/crates/tsv_ts/src/printer/statements/variable.rs
@@ -19,9 +19,13 @@ use tsv_lang::doc::arena::{DocArena, DocId};
 use tsv_lang::doc::{DocBuf, GroupId};
 use tsv_lang::{INDENT, PRINT_WIDTH};
 
-/// Wrap a doc in parentheses if the expression needs them for variable init context
-fn wrap_init_doc(d: &DocArena, init_doc: DocId, init: &Expression<'_>) -> DocId {
-    if needs_parens(init, ParenContext::VariableInit) {
+/// Wrap a doc in parentheses if the expression needs them for variable init context.
+/// `in_for_init` carries the for-header rule: a statement-level `const x = b in c`
+/// lexically under a for-header init (e.g. in a nested function body) parenthesizes
+/// the `in` like every other position there. (A for-header's *own* declarator is
+/// built in `build_for_init_doc`, not here.)
+fn wrap_init_doc(d: &DocArena, init_doc: DocId, init: &Expression<'_>, in_for_init: bool) -> DocId {
+    if needs_parens(init, ParenContext::VariableInit, in_for_init) {
         d.parens(init_doc)
     } else {
         init_doc
@@ -601,6 +605,7 @@ impl<'a> Printer<'a> {
                                     declarator.span.end,
                                 ),
                                 init,
+                                self.in_for_init.get(),
                             ),
                         ])));
                     } else {
@@ -613,6 +618,7 @@ impl<'a> Printer<'a> {
                                     declarator.span.end,
                                 ),
                                 init,
+                                self.in_for_init.get(),
                             ),
                         ])));
                     }
@@ -628,6 +634,7 @@ impl<'a> Printer<'a> {
                         d,
                         self.build_expression_doc_with_paren_comments(init, declarator.span.end),
                         init,
+                        self.in_for_init.get(),
                     );
                     let rhs_doc = d.concat(&[comments_doc, init_doc]);
                     parts.push(hang_after_operator(d, rhs_doc));
@@ -645,6 +652,7 @@ impl<'a> Printer<'a> {
                                 declarator.span.end,
                             ),
                             init,
+                            self.in_for_init.get(),
                         ),
                     ])));
                 } else if is_curried_arrow_chain(init) {
@@ -662,6 +670,7 @@ impl<'a> Printer<'a> {
                                     declarator.span.end,
                                 ),
                                 init,
+                                self.in_for_init.get(),
                             ))
                         },
                     );
@@ -708,6 +717,7 @@ impl<'a> Printer<'a> {
                         d,
                         self.build_expression_doc_with_paren_comments(init, declarator.span.end),
                         init,
+                        self.in_for_init.get(),
                     ));
                     parts.push(d.group(init_doc));
                 } else if is_type_assertion_with_lhs_type
@@ -734,6 +744,7 @@ impl<'a> Printer<'a> {
                         d,
                         self.build_expression_doc_with_paren_comments(init, declarator.span.end),
                         init,
+                        self.in_for_init.get(),
                     ));
                     parts.push(build_fluid_assignment_doc(
                         d,
@@ -753,6 +764,7 @@ impl<'a> Printer<'a> {
                         d,
                         self.build_expression_doc_with_paren_comments(init, declarator.span.end),
                         init,
+                        self.in_for_init.get(),
                     ));
                     parts.push(hang_after_operator(d, init_doc));
                 } else if is_layout_eligible && !is_simple_value(init) {
@@ -765,6 +777,7 @@ impl<'a> Printer<'a> {
                         d,
                         self.build_expression_doc_with_paren_comments(init, declarator.span.end),
                         init,
+                        self.in_for_init.get(),
                     ));
                     parts.push(build_fluid_assignment_doc(
                         d,
@@ -778,6 +791,7 @@ impl<'a> Printer<'a> {
                         d,
                         self.build_expression_doc_with_paren_comments(init, declarator.span.end),
                         init,
+                        self.in_for_init.get(),
                     ));
                     parts.push(init_doc);
                 }

--- a/docs/conformance_test262.md
+++ b/docs/conformance_test262.md
@@ -61,7 +61,7 @@ the for-header `[~In]` into them; now they parse, and the formatter parenthesize
 `in` anywhere under a for-init (matching prettier, keeping it distinct from the
 `for (x in y)` separator).
 
-**The ~188 acorn-also-rejects** are not tsv bugs — they split into:
+**The ~189 acorn-also-rejects** are not tsv bugs — they split into:
 **sloppy-mode-only** (`with`, AnnexB `f() = g()` / `for (var a = x in b)`, legacy
 octal — tsv is strict-only); **strict-*Script*-only** (top-level `await` as a
 *binding*, e.g. `var await = 1` — valid in a strict Script but not a Module;

--- a/docs/conformance_test262.md
+++ b/docs/conformance_test262.md
@@ -16,31 +16,25 @@ at `../test262`); refresh this list when the parser or the test262 snapshot
 changes — at minimum per release. Counts below are from a snapshot of ~49k
 discovered tests (46,545 graded after skips).
 
-- Positive (should parse) — 41,903 passed, 211 failed
+- Positive (should parse) — 41,907 passed, 207 failed
 - Negative (should reject) — 1,339 passed, 3,092 failed
 
-- **Overall**: 43,242/46,545 (92.9%)
+- **Overall**: 43,246/46,545 (92.9%)
 - **Positive pass rate**: 99.5% — valid syntax tsv accepts
 - **Skipped**: 2,591 (sloppy mode: 2,519, runtime: 38, resolution: 34)
 
-**Triaging the positive failures against the drop-in oracle.** Each of the 211 is
+**Triaging the positive failures against the drop-in oracle.** Each of the 207 is
 parsed with the canonical parser (acorn-typescript in module mode — what the
-fixtures' `expected.json` is generated from). **~23 are genuine tsv-vs-acorn bugs
-(acorn accepts, tsv rejects) — real parser gaps to close.** The remaining ~188
+fixtures' `expected.json` is generated from). **~18 are genuine tsv-vs-acorn bugs
+(acorn accepts, tsv rejects) — real parser gaps to close.** The remaining ~189
 are rejected by acorn too (not tsv-specific). _(Methodology: parse each
 `../test262/<path>` with `canonical_parse` and bucket on whether it yields an
 AST. An earlier triage used a wrong path prefix, so every file came back
 "not found" and was mis-bucketed as rejected — the corrected sweep below is
 authoritative.)_
 
-**The ~23 real bugs**, by cluster:
+**The ~18 real bugs**, by cluster:
 
-- **`in` not permitted where `[+In]` should be restored, inside a `for`-header (5)**
-  — the for-init disables `in` (`[~In]`), but nested sub-expressions must restore
-  `[+In]`: a computed class member/accessor name
-  (`for (C = class { get ['x' in y]() {} }; ;) {}`), a ternary branch, and a
-  dynamic-import 2nd argument. tsv leaks the for-header `[~In]` into them; the same
-  forms parse fine outside a for-header.
 - **Unicode `Other_ID_Start` / `Other_ID_Continue` identifiers (4)** — characters
   like `゛` (U+309B) and their escaped forms. tsv's `unicode-ident` uses the XID
   sets, which exclude the legacy `Other_ID_*` compatibility code points.
@@ -59,8 +53,13 @@ authoritative.)_
   position, and an assignment-target case.
 
 These are the actionable positive-conformance backlog (fixtures-first per the
-repo TDD gate). The ✅ tagged-template invalid-escape gap (ES2018) was one such
-bug and is now fixed.
+repo TDD gate). Two such gaps are now fixed: ✅ the tagged-template invalid-escape
+gap (ES2018), and ✅ the `[+In]` for-header reset — the for-init disables `in`
+(`[~In]`), but nested sub-expressions restore `[+In]` (computed class member name,
+ternary consequent, dynamic-import argument, function/class bodies). tsv had leaked
+the for-header `[~In]` into them; now they parse, and the formatter parenthesizes an
+`in` anywhere under a for-init (matching prettier, keeping it distinct from the
+`for (x in y)` separator).
 
 **The ~188 acorn-also-rejects** are not tsv bugs — they split into:
 **sloppy-mode-only** (`with`, AnnexB `f() = g()` / `for (var a = x in b)`, legacy

--- a/tests/fixtures/typescript/statements/for/header_in_operator/expected.json
+++ b/tests/fixtures/typescript/statements/for/header_in_operator/expected.json
@@ -1,0 +1,830 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 216,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": []
+	},
+	"options": null,
+	"comments": [],
+	"instance": {
+		"type": "Script",
+		"start": 0,
+		"end": 215,
+		"context": "default",
+		"content": {
+			"type": "Program",
+			"start": 8,
+			"end": 206,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 18,
+					"column": 9
+				}
+			},
+			"body": [
+				{
+					"type": "ForStatement",
+					"start": 10,
+					"end": 37,
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 1
+						},
+						"end": {
+							"line": 2,
+							"column": 28
+						}
+					},
+					"init": {
+						"type": "AssignmentExpression",
+						"start": 15,
+						"end": 27,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 6
+							},
+							"end": {
+								"line": 2,
+								"column": 18
+							}
+						},
+						"operator": "=",
+						"left": {
+							"type": "Identifier",
+							"start": 15,
+							"end": 16,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 6
+								},
+								"end": {
+									"line": 2,
+									"column": 7
+								}
+							},
+							"name": "a"
+						},
+						"right": {
+							"type": "BinaryExpression",
+							"start": 20,
+							"end": 26,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 11
+								},
+								"end": {
+									"line": 2,
+									"column": 17
+								}
+							},
+							"left": {
+								"type": "Identifier",
+								"start": 20,
+								"end": 21,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 11
+									},
+									"end": {
+										"line": 2,
+										"column": 12
+									}
+								},
+								"name": "b"
+							},
+							"operator": "in",
+							"right": {
+								"type": "Identifier",
+								"start": 25,
+								"end": 26,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 16
+									},
+									"end": {
+										"line": 2,
+										"column": 17
+									}
+								},
+								"name": "c"
+							}
+						}
+					},
+					"test": {
+						"type": "Identifier",
+						"start": 29,
+						"end": 30,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 20
+							},
+							"end": {
+								"line": 2,
+								"column": 21
+							}
+						},
+						"name": "d"
+					},
+					"update": {
+						"type": "Identifier",
+						"start": 32,
+						"end": 33,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 23
+							},
+							"end": {
+								"line": 2,
+								"column": 24
+							}
+						},
+						"name": "e"
+					},
+					"body": {
+						"type": "BlockStatement",
+						"start": 35,
+						"end": 37,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 26
+							},
+							"end": {
+								"line": 2,
+								"column": 28
+							}
+						},
+						"body": []
+					}
+				},
+				{
+					"type": "ForStatement",
+					"start": 39,
+					"end": 77,
+					"loc": {
+						"start": {
+							"line": 3,
+							"column": 1
+						},
+						"end": {
+							"line": 3,
+							"column": 39
+						}
+					},
+					"init": {
+						"type": "AssignmentExpression",
+						"start": 44,
+						"end": 67,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 6
+							},
+							"end": {
+								"line": 3,
+								"column": 29
+							}
+						},
+						"operator": "=",
+						"left": {
+							"type": "Identifier",
+							"start": 44,
+							"end": 45,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 6
+								},
+								"end": {
+									"line": 3,
+									"column": 7
+								}
+							},
+							"name": "a"
+						},
+						"right": {
+							"type": "ConditionalExpression",
+							"start": 48,
+							"end": 67,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 10
+								},
+								"end": {
+									"line": 3,
+									"column": 29
+								}
+							},
+							"test": {
+								"type": "Identifier",
+								"start": 48,
+								"end": 52,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 10
+									},
+									"end": {
+										"line": 3,
+										"column": 14
+									}
+								},
+								"name": "cond"
+							},
+							"consequent": {
+								"type": "BinaryExpression",
+								"start": 56,
+								"end": 62,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 18
+									},
+									"end": {
+										"line": 3,
+										"column": 24
+									}
+								},
+								"left": {
+									"type": "Identifier",
+									"start": 56,
+									"end": 57,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 18
+										},
+										"end": {
+											"line": 3,
+											"column": 19
+										}
+									},
+									"name": "b"
+								},
+								"operator": "in",
+								"right": {
+									"type": "Identifier",
+									"start": 61,
+									"end": 62,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 23
+										},
+										"end": {
+											"line": 3,
+											"column": 24
+										}
+									},
+									"name": "c"
+								}
+							},
+							"alternate": {
+								"type": "Literal",
+								"start": 66,
+								"end": 67,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 28
+									},
+									"end": {
+										"line": 3,
+										"column": 29
+									}
+								},
+								"value": 0,
+								"raw": "0"
+							}
+						}
+					},
+					"test": {
+						"type": "Identifier",
+						"start": 69,
+						"end": 70,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 31
+							},
+							"end": {
+								"line": 3,
+								"column": 32
+							}
+						},
+						"name": "d"
+					},
+					"update": {
+						"type": "Identifier",
+						"start": 72,
+						"end": 73,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 34
+							},
+							"end": {
+								"line": 3,
+								"column": 35
+							}
+						},
+						"name": "e"
+					},
+					"body": {
+						"type": "BlockStatement",
+						"start": 75,
+						"end": 77,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 37
+							},
+							"end": {
+								"line": 3,
+								"column": 39
+							}
+						},
+						"body": []
+					}
+				},
+				{
+					"type": "ForStatement",
+					"start": 79,
+					"end": 141,
+					"loc": {
+						"start": {
+							"line": 4,
+							"column": 1
+						},
+						"end": {
+							"line": 10,
+							"column": 5
+						}
+					},
+					"init": {
+						"type": "AssignmentExpression",
+						"start": 87,
+						"end": 125,
+						"loc": {
+							"start": {
+								"line": 5,
+								"column": 2
+							},
+							"end": {
+								"line": 7,
+								"column": 3
+							}
+						},
+						"operator": "=",
+						"left": {
+							"type": "Identifier",
+							"start": 87,
+							"end": 88,
+							"loc": {
+								"start": {
+									"line": 5,
+									"column": 2
+								},
+								"end": {
+									"line": 5,
+									"column": 3
+								}
+							},
+							"name": "C"
+						},
+						"right": {
+							"type": "ClassExpression",
+							"start": 91,
+							"end": 125,
+							"loc": {
+								"start": {
+									"line": 5,
+									"column": 6
+								},
+								"end": {
+									"line": 7,
+									"column": 3
+								}
+							},
+							"id": null,
+							"superClass": null,
+							"body": {
+								"type": "ClassBody",
+								"start": 97,
+								"end": 125,
+								"loc": {
+									"start": {
+										"line": 5,
+										"column": 12
+									},
+									"end": {
+										"line": 7,
+										"column": 3
+									}
+								},
+								"body": [
+									{
+										"type": "MethodDefinition",
+										"start": 102,
+										"end": 121,
+										"loc": {
+											"start": {
+												"line": 6,
+												"column": 3
+											},
+											"end": {
+												"line": 6,
+												"column": 22
+											}
+										},
+										"static": false,
+										"computed": true,
+										"key": {
+											"type": "BinaryExpression",
+											"start": 108,
+											"end": 114,
+											"loc": {
+												"start": {
+													"line": 6,
+													"column": 9
+												},
+												"end": {
+													"line": 6,
+													"column": 15
+												}
+											},
+											"left": {
+												"type": "Identifier",
+												"start": 108,
+												"end": 109,
+												"loc": {
+													"start": {
+														"line": 6,
+														"column": 9
+													},
+													"end": {
+														"line": 6,
+														"column": 10
+													}
+												},
+												"name": "b"
+											},
+											"operator": "in",
+											"right": {
+												"type": "Identifier",
+												"start": 113,
+												"end": 114,
+												"loc": {
+													"start": {
+														"line": 6,
+														"column": 14
+													},
+													"end": {
+														"line": 6,
+														"column": 15
+													}
+												},
+												"name": "c"
+											}
+										},
+										"kind": "get",
+										"value": {
+											"type": "FunctionExpression",
+											"start": 116,
+											"end": 121,
+											"loc": {
+												"start": {
+													"line": 6,
+													"column": 17
+												},
+												"end": {
+													"line": 6,
+													"column": 22
+												}
+											},
+											"id": null,
+											"expression": false,
+											"generator": false,
+											"async": false,
+											"params": [],
+											"body": {
+												"type": "BlockStatement",
+												"start": 119,
+												"end": 121,
+												"loc": {
+													"start": {
+														"line": 6,
+														"column": 20
+													},
+													"end": {
+														"line": 6,
+														"column": 22
+													}
+												},
+												"body": []
+											}
+										}
+									}
+								]
+							}
+						}
+					},
+					"test": {
+						"type": "Identifier",
+						"start": 129,
+						"end": 130,
+						"loc": {
+							"start": {
+								"line": 8,
+								"column": 2
+							},
+							"end": {
+								"line": 8,
+								"column": 3
+							}
+						},
+						"name": "d"
+					},
+					"update": {
+						"type": "Identifier",
+						"start": 134,
+						"end": 135,
+						"loc": {
+							"start": {
+								"line": 9,
+								"column": 2
+							},
+							"end": {
+								"line": 9,
+								"column": 3
+							}
+						},
+						"name": "e"
+					},
+					"body": {
+						"type": "BlockStatement",
+						"start": 139,
+						"end": 141,
+						"loc": {
+							"start": {
+								"line": 10,
+								"column": 3
+							},
+							"end": {
+								"line": 10,
+								"column": 5
+							}
+						},
+						"body": []
+					}
+				},
+				{
+					"type": "ForStatement",
+					"start": 143,
+					"end": 205,
+					"loc": {
+						"start": {
+							"line": 11,
+							"column": 1
+						},
+						"end": {
+							"line": 17,
+							"column": 5
+						}
+					},
+					"init": {
+						"type": "AssignmentExpression",
+						"start": 151,
+						"end": 189,
+						"loc": {
+							"start": {
+								"line": 12,
+								"column": 2
+							},
+							"end": {
+								"line": 14,
+								"column": 3
+							}
+						},
+						"operator": "=",
+						"left": {
+							"type": "Identifier",
+							"start": 151,
+							"end": 152,
+							"loc": {
+								"start": {
+									"line": 12,
+									"column": 2
+								},
+								"end": {
+									"line": 12,
+									"column": 3
+								}
+							},
+							"name": "a"
+						},
+						"right": {
+							"type": "FunctionExpression",
+							"start": 155,
+							"end": 189,
+							"loc": {
+								"start": {
+									"line": 12,
+									"column": 6
+								},
+								"end": {
+									"line": 14,
+									"column": 3
+								}
+							},
+							"id": null,
+							"expression": false,
+							"generator": false,
+							"async": false,
+							"params": [],
+							"body": {
+								"type": "BlockStatement",
+								"start": 167,
+								"end": 189,
+								"loc": {
+									"start": {
+										"line": 12,
+										"column": 18
+									},
+									"end": {
+										"line": 14,
+										"column": 3
+									}
+								},
+								"body": [
+									{
+										"type": "ExpressionStatement",
+										"start": 172,
+										"end": 185,
+										"loc": {
+											"start": {
+												"line": 13,
+												"column": 3
+											},
+											"end": {
+												"line": 13,
+												"column": 16
+											}
+										},
+										"expression": {
+											"type": "AssignmentExpression",
+											"start": 172,
+											"end": 184,
+											"loc": {
+												"start": {
+													"line": 13,
+													"column": 3
+												},
+												"end": {
+													"line": 13,
+													"column": 15
+												}
+											},
+											"operator": "=",
+											"left": {
+												"type": "Identifier",
+												"start": 172,
+												"end": 173,
+												"loc": {
+													"start": {
+														"line": 13,
+														"column": 3
+													},
+													"end": {
+														"line": 13,
+														"column": 4
+													}
+												},
+												"name": "z"
+											},
+											"right": {
+												"type": "BinaryExpression",
+												"start": 177,
+												"end": 183,
+												"loc": {
+													"start": {
+														"line": 13,
+														"column": 8
+													},
+													"end": {
+														"line": 13,
+														"column": 14
+													}
+												},
+												"left": {
+													"type": "Identifier",
+													"start": 177,
+													"end": 178,
+													"loc": {
+														"start": {
+															"line": 13,
+															"column": 8
+														},
+														"end": {
+															"line": 13,
+															"column": 9
+														}
+													},
+													"name": "b"
+												},
+												"operator": "in",
+												"right": {
+													"type": "Identifier",
+													"start": 182,
+													"end": 183,
+													"loc": {
+														"start": {
+															"line": 13,
+															"column": 13
+														},
+														"end": {
+															"line": 13,
+															"column": 14
+														}
+													},
+													"name": "c"
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					},
+					"test": {
+						"type": "Identifier",
+						"start": 193,
+						"end": 194,
+						"loc": {
+							"start": {
+								"line": 15,
+								"column": 2
+							},
+							"end": {
+								"line": 15,
+								"column": 3
+							}
+						},
+						"name": "d"
+					},
+					"update": {
+						"type": "Identifier",
+						"start": 198,
+						"end": 199,
+						"loc": {
+							"start": {
+								"line": 16,
+								"column": 2
+							},
+							"end": {
+								"line": 16,
+								"column": 3
+							}
+						},
+						"name": "e"
+					},
+					"body": {
+						"type": "BlockStatement",
+						"start": 203,
+						"end": 205,
+						"loc": {
+							"start": {
+								"line": 17,
+								"column": 3
+							},
+							"end": {
+								"line": 17,
+								"column": 5
+							}
+						},
+						"body": []
+					}
+				}
+			],
+			"sourceType": "module"
+		},
+		"attributes": []
+	}
+}

--- a/tests/fixtures/typescript/statements/for/header_in_operator/input.svelte
+++ b/tests/fixtures/typescript/statements/for/header_in_operator/input.svelte
@@ -1,0 +1,18 @@
+<script>
+	for (a = (b in c); d; e) {}
+	for (a = cond ? (b in c) : 0; d; e) {}
+	for (
+		C = class {
+			get [(b in c)]() {}
+		};
+		d;
+		e
+	) {}
+	for (
+		a = function () {
+			z = (b in c);
+		};
+		d;
+		e
+	) {}
+</script>

--- a/tests/fixtures/typescript/statements/for/header_in_operator/input_invalid_arrow_concise_body.svelte
+++ b/tests/fixtures/typescript/statements/for/header_in_operator/input_invalid_arrow_concise_body.svelte
@@ -1,0 +1,3 @@
+<script>
+	for (a = () => b in c; d; e) {}
+</script>

--- a/tests/fixtures/typescript/statements/for/header_in_operator/input_invalid_ternary_alternate.svelte
+++ b/tests/fixtures/typescript/statements/for/header_in_operator/input_invalid_ternary_alternate.svelte
@@ -1,0 +1,3 @@
+<script>
+	for (a = cond ? 0 : b in c; d; e) {}
+</script>

--- a/tests/fixtures/typescript/statements/for/header_in_operator/unformatted_no_parens.svelte
+++ b/tests/fixtures/typescript/statements/for/header_in_operator/unformatted_no_parens.svelte
@@ -1,0 +1,6 @@
+<script>
+	for (a = (b in c); d; e) {}
+	for (a = cond ? b in c : 0; d; e) {}
+	for (C = class { get [b in c]() {} }; d; e) {}
+	for (a = function () { z = b in c; }; d; e) {}
+</script>

--- a/tests/fixtures/typescript/statements/for/init_in_dynamic_import/expected.json
+++ b/tests/fixtures/typescript/statements/for/init_in_dynamic_import/expected.json
@@ -1,0 +1,195 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 41,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "ForStatement",
+			"start": 0,
+			"end": 40,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 40
+				}
+			},
+			"init": {
+				"type": "AssignmentExpression",
+				"start": 5,
+				"end": 30,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 5
+					},
+					"end": {
+						"line": 1,
+						"column": 30
+					}
+				},
+				"operator": "=",
+				"left": {
+					"type": "Identifier",
+					"start": 5,
+					"end": 6,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 5
+						},
+						"end": {
+							"line": 1,
+							"column": 6
+						}
+					},
+					"name": "a"
+				},
+				"right": {
+					"type": "ImportExpression",
+					"start": 9,
+					"end": 30,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 9
+						},
+						"end": {
+							"line": 1,
+							"column": 30
+						}
+					},
+					"source": {
+						"type": "Literal",
+						"start": 16,
+						"end": 19,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 16
+							},
+							"end": {
+								"line": 1,
+								"column": 19
+							}
+						},
+						"value": "m",
+						"raw": "'m'"
+					},
+					"arguments": [
+						{
+							"type": "BinaryExpression",
+							"start": 22,
+							"end": 28,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 22
+								},
+								"end": {
+									"line": 1,
+									"column": 28
+								}
+							},
+							"left": {
+								"type": "Identifier",
+								"start": 22,
+								"end": 23,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 22
+									},
+									"end": {
+										"line": 1,
+										"column": 23
+									}
+								},
+								"name": "b"
+							},
+							"operator": "in",
+							"right": {
+								"type": "Identifier",
+								"start": 27,
+								"end": 28,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 27
+									},
+									"end": {
+										"line": 1,
+										"column": 28
+									}
+								},
+								"name": "c"
+							}
+						}
+					]
+				}
+			},
+			"test": {
+				"type": "Identifier",
+				"start": 32,
+				"end": 33,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 32
+					},
+					"end": {
+						"line": 1,
+						"column": 33
+					}
+				},
+				"name": "d"
+			},
+			"update": {
+				"type": "Identifier",
+				"start": 35,
+				"end": 36,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 35
+					},
+					"end": {
+						"line": 1,
+						"column": 36
+					}
+				},
+				"name": "e"
+			},
+			"body": {
+				"type": "BlockStatement",
+				"start": 38,
+				"end": 40,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 38
+					},
+					"end": {
+						"line": 1,
+						"column": 40
+					}
+				},
+				"body": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/tests/fixtures/typescript/statements/for/init_in_dynamic_import/input.ts
+++ b/tests/fixtures/typescript/statements/for/init_in_dynamic_import/input.ts
@@ -1,0 +1,1 @@
+for (a = import('m', (b in c)); d; e) {}

--- a/tests/fixtures/typescript/statements/for/init_in_dynamic_import/unformatted_no_parens.ts
+++ b/tests/fixtures/typescript/statements/for/init_in_dynamic_import/unformatted_no_parens.ts
@@ -1,0 +1,1 @@
+for (a = import('m', b in c); d; e) {}


### PR DESCRIPTION
Prettier over-parenthesizes from the spec's requirements and tsv follows suit for readability.