### PR TITLE
perf: rework ts parser to box the expression in ParsedExpr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ tsv has no config that changes its formatting style behavior, and none will be a
   [#137](https://github.com/fuzdev/tsv/pull/137), [#143](https://github.com/fuzdev/tsv/pull/143),
   [#145](https://github.com/fuzdev/tsv/pull/145), [#147](https://github.com/fuzdev/tsv/pull/147),
   [#148](https://github.com/fuzdev/tsv/pull/148), [#151](https://github.com/fuzdev/tsv/pull/151),
-  [#156](https://github.com/fuzdev/tsv/pull/156), [#165](https://github.com/fuzdev/tsv/pull/165))
+  [#156](https://github.com/fuzdev/tsv/pull/156), [#165](https://github.com/fuzdev/tsv/pull/165),
+  [#199](https://github.com/fuzdev/tsv/pull/199))
 
 ## 0.1.0
 

--- a/crates/tsv_ts/src/ast/internal/expressions.rs
+++ b/crates/tsv_ts/src/ast/internal/expressions.rs
@@ -27,11 +27,15 @@ pub enum Expression<'arena> {
     MemberExpression(MemberExpression<'arena>),
     ConditionalExpression(ConditionalExpression<'arena>),
     // Inline by value: the layout favors traversal locality over node size, so
-    // fat variants are kept inline rather than arena-boxed (boxing added a
-    // pointer-chase on hot format-read paths).
+    // format-hot variants are kept inline rather than arena-boxed (boxing added a
+    // pointer-chase on hot format-read paths). The exception is the rare-and-fattest
+    // variants, arena-boxed to shrink the enum (which every `parse_*` returns by
+    // value up the recursion) without touching the hot format-read path: a class
+    // expression is rare in real code and never on a format hot loop, so the bump
+    // `&'arena` deref it costs is cheaper than the per-`parse_*` copy it saves.
     ArrowFunctionExpression(ArrowFunctionExpression<'arena>),
     FunctionExpression(FunctionExpression<'arena>),
-    ClassExpression(ClassExpression<'arena>),
+    ClassExpression(&'arena ClassExpression<'arena>),
     SpreadElement(SpreadElement<'arena>),
     TemplateLiteral(TemplateLiteral<'arena>),
     TaggedTemplateExpression(TaggedTemplateExpression<'arena>),

--- a/crates/tsv_ts/src/ast/internal/expressions.rs
+++ b/crates/tsv_ts/src/ast/internal/expressions.rs
@@ -27,8 +27,12 @@ pub enum Expression<'arena> {
     MemberExpression(MemberExpression<'arena>),
     ConditionalExpression(ConditionalExpression<'arena>),
     // Inline by value: the layout favors traversal locality over node size, so
-    // fat variants are kept inline rather than arena-boxed (boxing added a
-    // pointer-chase on hot format-read paths).
+    // fat variants are kept inline rather than arena-boxed (boxing them shrinks the
+    // enum but adds a pointer-chase on the hot format-read paths that costs more than
+    // the density win). The fat enum is not a parse-return cost either: the parser
+    // threads expressions up the recursive descent by reference (its transient
+    // `ParsedExpr` holds an `&'arena Expression`), so the recursion moves pointers,
+    // not whole nodes — a fat inline variant is not a reason to box it.
     ArrowFunctionExpression(ArrowFunctionExpression<'arena>),
     FunctionExpression(FunctionExpression<'arena>),
     ClassExpression(ClassExpression<'arena>),

--- a/crates/tsv_ts/src/ast/internal/expressions.rs
+++ b/crates/tsv_ts/src/ast/internal/expressions.rs
@@ -27,15 +27,11 @@ pub enum Expression<'arena> {
     MemberExpression(MemberExpression<'arena>),
     ConditionalExpression(ConditionalExpression<'arena>),
     // Inline by value: the layout favors traversal locality over node size, so
-    // format-hot variants are kept inline rather than arena-boxed (boxing added a
-    // pointer-chase on hot format-read paths). The exception is the rare-and-fattest
-    // variants, arena-boxed to shrink the enum (which every `parse_*` returns by
-    // value up the recursion) without touching the hot format-read path: a class
-    // expression is rare in real code and never on a format hot loop, so the bump
-    // `&'arena` deref it costs is cheaper than the per-`parse_*` copy it saves.
+    // fat variants are kept inline rather than arena-boxed (boxing added a
+    // pointer-chase on hot format-read paths).
     ArrowFunctionExpression(ArrowFunctionExpression<'arena>),
     FunctionExpression(FunctionExpression<'arena>),
-    ClassExpression(&'arena ClassExpression<'arena>),
+    ClassExpression(ClassExpression<'arena>),
     SpreadElement(SpreadElement<'arena>),
     TemplateLiteral(TemplateLiteral<'arena>),
     TaggedTemplateExpression(TaggedTemplateExpression<'arena>),

--- a/crates/tsv_ts/src/parser/expression.rs
+++ b/crates/tsv_ts/src/parser/expression.rs
@@ -90,7 +90,9 @@ impl<'arena> ParsedExpr<'arena> {
     }
 
     /// Create a ParsedExpr from an already-arena-boxed expression with explicit
-    /// bounds (for parenthesized expressions that reuse the inner's allocation).
+    /// paren bounds. Unlike `from_expr`/`with_end`, the caller supplies the
+    /// `&'arena Expression` — the inner's own allocation reused (parenthesized
+    /// expression) or a freshly built wrapper node (JSDoc cast).
     fn with_bounds(
         expr: &'arena Expression<'arena>,
         actual_start: usize,

--- a/crates/tsv_ts/src/parser/expression.rs
+++ b/crates/tsv_ts/src/parser/expression.rs
@@ -48,10 +48,18 @@ const BP_UNARY: u8 = 29;
 /// Example: `(a ? b : c)()`
 /// - Inner ternary: span = `a ? b : c` (semantic, excludes parens)
 /// - CallExpression: span starts at `actual_start` (the `(`), not ternary's start
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct ParsedExpr<'arena> {
-    /// The parsed expression with semantic span (may exclude surrounding parens)
-    expr: Expression<'arena>,
+    /// The parsed expression with semantic span (may exclude surrounding parens).
+    ///
+    /// Arena-boxed (not held by value): the parser's recursion threads `ParsedExpr`
+    /// up the precedence ladder, so keeping the fat `Expression` (160 B) inline made
+    /// every `parse_*` return a ~176 B value by sret. The expression is allocated in
+    /// the arena where it is built (where most callers already re-`alloc`'d it as a
+    /// child anyway), so the recursion moves an 8 B reference instead. The format
+    /// printer is unaffected: it reads the `Expression` enum, whose definition is
+    /// unchanged — only this parser-internal wrapper holds a reference.
+    expr: &'arena Expression<'arena>,
     /// Actual start position before any opening parentheses
     actual_start: usize,
     /// Actual end position after consuming any closing parentheses
@@ -59,8 +67,10 @@ struct ParsedExpr<'arena> {
 }
 
 impl<'arena> ParsedExpr<'arena> {
-    /// Create a ParsedExpr where actual_start/end match the expression's semantic span
-    fn from_expr(expr: Expression<'arena>) -> Self {
+    /// Create a ParsedExpr where actual_start/end match the expression's semantic
+    /// span. The expression is arena-boxed here (see the `expr` field doc).
+    fn from_expr(arena: &'arena bumpalo::Bump, expr: Expression<'arena>) -> Self {
+        let expr = arena.alloc(expr);
         let span = expr.span();
         Self {
             actual_start: span.start_usize(),
@@ -70,7 +80,8 @@ impl<'arena> ParsedExpr<'arena> {
     }
 
     /// Create a ParsedExpr with explicit actual_end (for parenthesized expressions)
-    fn with_end(expr: Expression<'arena>, actual_end: usize) -> Self {
+    fn with_end(arena: &'arena bumpalo::Bump, expr: Expression<'arena>, actual_end: usize) -> Self {
+        let expr = arena.alloc(expr);
         Self {
             actual_start: expr.span().start_usize(),
             actual_end,
@@ -78,8 +89,13 @@ impl<'arena> ParsedExpr<'arena> {
         }
     }
 
-    /// Create a ParsedExpr with explicit actual_start and actual_end (for parenthesized expressions)
-    fn with_bounds(expr: Expression<'arena>, actual_start: usize, actual_end: usize) -> Self {
+    /// Create a ParsedExpr from an already-arena-boxed expression with explicit
+    /// bounds (for parenthesized expressions that reuse the inner's allocation).
+    fn with_bounds(
+        expr: &'arena Expression<'arena>,
+        actual_start: usize,
+        actual_end: usize,
+    ) -> Self {
         Self {
             expr,
             actual_start,
@@ -189,7 +205,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     /// the comma operator (sequence expression). Use `parse_assignment_expression()`
     /// for contexts where comma is a separator (function args, array elements, etc.)
     pub(super) fn parse_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        Ok(self.parse_expression_bp(BP_COMMA)?.expr)
+        // The spine returns an arena ref; the public boundary hands back an owned
+        // `Expression` (shallow clone — children are refs) for by-value AST fields.
+        Ok(self.parse_expression_bp(BP_COMMA)?.expr.clone())
     }
 
     /// Parse an assignment expression (excludes comma operator)
@@ -203,7 +221,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     /// To use the comma operator in these contexts, wrap in parens: `foo((a, b))`
     pub(super) fn parse_assignment_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
         // Use BP_ASSIGNMENT to skip comma handling (which only triggers at BP_COMMA)
-        Ok(self.parse_expression_bp(BP_ASSIGNMENT)?.expr)
+        Ok(self.parse_expression_bp(BP_ASSIGNMENT)?.expr.clone())
     }
 
     /// Parse an expression without allowing `in` as a binary operator.
@@ -302,12 +320,12 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 // Use right.actual_end (position after parsing) to include closing parens
                 let span = Span::new(expr_start as u32, right.actual_end as u32);
                 left = ParsedExpr {
-                    expr: Expression::BinaryExpression(BinaryExpression {
-                        left: arena.alloc(left.expr),
+                    expr: arena.alloc(Expression::BinaryExpression(BinaryExpression {
+                        left: left.expr,
                         operator,
-                        right: arena.alloc(right.expr),
+                        right: right.expr,
                         span,
-                    }),
+                    })),
                     actual_start: expr_start,
                     actual_end: right.actual_end,
                 };
@@ -325,11 +343,11 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                         let type_annotation = arena.alloc(self.parse_type_no_asi_bracket()?);
                         let span = Span::new(expr_start as u32, type_annotation.span().end);
                         left = ParsedExpr {
-                            expr: Expression::TSAsExpression(TSAsExpression {
-                                expression: arena.alloc(left.expr),
+                            expr: arena.alloc(Expression::TSAsExpression(TSAsExpression {
+                                expression: left.expr,
                                 type_annotation,
                                 span,
-                            }),
+                            })),
                             actual_start: expr_start,
                             actual_end: span.end_usize(),
                         };
@@ -341,11 +359,13 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                         let type_annotation = arena.alloc(self.parse_type_no_asi_bracket()?);
                         let span = Span::new(expr_start as u32, type_annotation.span().end);
                         left = ParsedExpr {
-                            expr: Expression::TSSatisfiesExpression(TSSatisfiesExpression {
-                                expression: arena.alloc(left.expr),
-                                type_annotation,
-                                span,
-                            }),
+                            expr: arena.alloc(Expression::TSSatisfiesExpression(
+                                TSSatisfiesExpression {
+                                    expression: left.expr,
+                                    type_annotation,
+                                    span,
+                                },
+                            )),
                             actual_start: expr_start,
                             actual_end: span.end_usize(),
                         };
@@ -371,17 +391,19 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             // Parse right-hand side (assignment is right-associative, so same precedence)
             let right = self.parse_expression_bp(BP_ASSIGNMENT)?;
 
-            // Convert left side to pattern if needed (cover grammar)
-            let left_pattern = self.to_assignable(left.expr)?;
+            // Convert left side to pattern if needed (cover grammar). `to_assignable`
+            // consumes by value; clone the arena ref (shallow — children are refs) on
+            // this cold assignment-target path.
+            let left_pattern = self.to_assignable(left.expr.clone())?;
 
             let span = Span::new(expr_start as u32, right.actual_end as u32);
             left = ParsedExpr {
-                expr: Expression::AssignmentExpression(AssignmentExpression {
+                expr: arena.alloc(Expression::AssignmentExpression(AssignmentExpression {
                     left: arena.alloc(left_pattern),
                     operator,
-                    right: arena.alloc(right.expr),
+                    right: right.expr,
                     span,
-                }),
+                })),
                 actual_start: expr_start,
                 actual_end: right.actual_end,
             };
@@ -406,12 +428,12 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
             let span = Span::new(expr_start as u32, alternate.actual_end as u32);
             left = ParsedExpr {
-                expr: Expression::ConditionalExpression(ConditionalExpression {
-                    test: arena.alloc(left.expr),
-                    consequent: arena.alloc(consequent.expr),
-                    alternate: arena.alloc(alternate.expr),
+                expr: arena.alloc(Expression::ConditionalExpression(ConditionalExpression {
+                    test: left.expr,
+                    consequent: consequent.expr,
+                    alternate: alternate.expr,
                     span,
-                }),
+                })),
                 actual_start: expr_start,
                 actual_end: alternate.actual_end,
             };
@@ -422,22 +444,24 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         // function calls, array literals, and object literals
         if min_bp == BP_COMMA && self.check(&TokenKind::Comma) {
             let mut expressions = self.bvec();
-            expressions.push(left.expr);
+            // SequenceExpression stores its elements by value; clone the arena refs
+            // (shallow) into the slice. Sequence expressions are rare.
+            expressions.push(left.expr.clone());
             let mut last_end = left.actual_end;
 
             while self.eat(TokenKind::Comma) {
                 // Parse next expression - use BP_ASSIGNMENT to stop before next comma
                 let next = self.parse_expression_bp(BP_ASSIGNMENT)?;
-                expressions.push(next.expr);
+                expressions.push(next.expr.clone());
                 last_end = next.actual_end;
             }
 
             let span = Span::new(expr_start as u32, last_end as u32);
             left = ParsedExpr {
-                expr: Expression::SequenceExpression(SequenceExpression {
+                expr: arena.alloc(Expression::SequenceExpression(SequenceExpression {
                     expressions: expressions.into_bump_slice(),
                     span,
-                }),
+                })),
                 actual_start: expr_start,
                 actual_end: last_end,
             };
@@ -451,35 +475,35 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         let parsed = match self.current_kind() {
             TokenKind::Minus | TokenKind::Plus | TokenKind::Bang | TokenKind::Tilde => {
                 let expr = self.parse_unary_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::PlusPlus | TokenKind::MinusMinus => {
                 let expr = self.parse_prefix_update_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::Keyword(KeywordKind::New) => {
                 let expr = self.parse_new_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::Keyword(KeywordKind::Import) => {
                 // Could be: import('module') or import.meta
                 let expr = self.parse_import_or_meta_property()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::Keyword(KeywordKind::Typeof | KeywordKind::Void | KeywordKind::Delete) => {
                 let expr = self.parse_unary_keyword_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::Keyword(KeywordKind::Await) => {
                 if self.in_await {
                     // `[+Await]` context: a real await expression.
                     let expr = self.parse_await_expression()?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 } else if self.await_is_identifier() {
                     if self.is_single_param_arrow_start() {
                         // Script `[~Await]`: `await => …` is an arrow whose single
                         // `BindingIdentifier` parameter is `await`.
-                        ParsedExpr::from_expr(self.parse_single_param_arrow_function()?)
+                        ParsedExpr::from_expr(self.arena, self.parse_single_param_arrow_function()?)
                     } else {
                         // Script `[~Await]`: `await` is an ordinary `IdentifierReference`.
                         self.parse_await_identifier_reference()?
@@ -494,7 +518,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             }
             TokenKind::Keyword(KeywordKind::Yield) => {
                 let expr = self.parse_yield_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::Keyword(KeywordKind::Async) => {
                 // Could be async arrow function, async function expression, or just identifier
@@ -505,7 +529,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                     let (start, _) = self.current_pos();
                     self.advance()?; // consume 'async'
                     let expr = self.parse_async_function_expression(start)?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 } else if peek == TokenKind::ParenOpen {
                     // `async(...)` — could be async arrow or call to function named `async`
                     // Scan ahead: if `(...)` is followed by `=>`, it's an async arrow function
@@ -514,7 +538,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                         let (start, _) = self.current_pos();
                         self.advance()?; // consume 'async'
                         let expr = self.parse_async_arrow_function_after_async(start)?;
-                        ParsedExpr::from_expr(expr)
+                        ParsedExpr::from_expr(self.arena, expr)
                     } else {
                         // `async(2)` — call to function named `async`
                         self.parse_primary_expression_with_end()?
@@ -524,7 +548,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                     let (start, _) = self.current_pos();
                     self.advance()?; // consume 'async'
                     let expr = self.parse_async_arrow_function_after_async(start)?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 } else {
                     // `async` used as identifier (e.g., `[async]`, `async = 1`)
                     self.parse_primary_expression_with_end()?
@@ -535,34 +559,34 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 // otherwise statement-only; in expression position the only thing
                 // that may follow a decorator list is a class expression.
                 let expr = self.parse_decorated_class_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::Keyword(KeywordKind::Class) => {
                 // Class expression: `class { }` or `class Foo<T> { }`
                 let expr = self.parse_class_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::Keyword(KeywordKind::Function) => {
                 // Function expression: `function() {}` or `function name() {}`
                 let expr = self.parse_function_expression()?;
-                ParsedExpr::from_expr(expr)
+                ParsedExpr::from_expr(self.arena, expr)
             }
             TokenKind::LessThan => {
                 // Generic arrow function: `<T>() => ...`
                 if self.is_generic_arrow_function_start() {
                     let expr = self.parse_generic_arrow_function()?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 } else {
                     // TypeScript type assertion: `<T>expr`
                     let expr = self.parse_type_assertion()?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 }
             }
             TokenKind::Identifier => {
                 // Check for single-param arrow function: `x => expr`
                 if self.is_single_param_arrow_start() {
                     let expr = self.parse_single_param_arrow_function()?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 } else {
                     // Regular identifier
                     self.parse_primary_expression_with_end()?
@@ -628,8 +652,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         self.advance()?; // consume '!'
         let span = Span::new(expr.actual_start as u32, op_end as u32);
         Ok(ParsedExpr::with_end(
+            self.arena,
             Expression::TSNonNullExpression(TSNonNullExpression {
-                expression: self.alloc(expr.expr),
+                expression: expr.expr,
                 span,
             }),
             op_end,
@@ -678,8 +703,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                     let span = Span::new(left.actual_start as u32, prop_end as u32);
                     left = ParsedExpr::with_end(
+                        self.arena,
                         Expression::MemberExpression(MemberExpression {
-                            object: arena.alloc(left.expr),
+                            object: left.expr,
                             property: arena.alloc(property),
                             computed: false,
                             optional: false,
@@ -701,8 +727,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                             let span = Span::new(left.actual_start as u32, prop_end as u32);
                             left = ParsedExpr::with_end(
+                                self.arena,
                                 Expression::MemberExpression(MemberExpression {
-                                    object: arena.alloc(left.expr),
+                                    object: left.expr,
                                     property: arena
                                         .alloc(Expression::PrivateIdentifier(private_id)),
                                     computed: false,
@@ -721,8 +748,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                             let span = Span::new(left.actual_start as u32, prop_end as u32);
                             left = ParsedExpr::with_end(
+                                self.arena,
                                 Expression::MemberExpression(MemberExpression {
-                                    object: arena.alloc(left.expr),
+                                    object: left.expr,
                                     property: arena.alloc(Expression::Identifier(
                                         Identifier::simple(
                                             name,
@@ -749,8 +777,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                             let span = Span::new(left.actual_start as u32, bracket_end as u32);
                             left = ParsedExpr::with_end(
+                                self.arena,
                                 Expression::MemberExpression(MemberExpression {
-                                    object: arena.alloc(left.expr),
+                                    object: left.expr,
                                     property: arena.alloc(index),
                                     computed: true,
                                     optional: true,
@@ -767,8 +796,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                             let span = Span::new(left.actual_start as u32, paren_end as u32);
                             left = ParsedExpr::with_end(
+                                self.arena,
                                 Expression::CallExpression(CallExpression {
-                                    callee: arena.alloc(left.expr),
+                                    callee: left.expr,
                                     type_arguments: None,
                                     arguments,
                                     optional: true,
@@ -793,8 +823,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                             let span = Span::new(left.actual_start as u32, paren_end as u32);
                             left = ParsedExpr::with_end(
+                                self.arena,
                                 Expression::CallExpression(CallExpression {
-                                    callee: arena.alloc(left.expr),
+                                    callee: left.expr,
                                     type_arguments: Some(type_args),
                                     arguments,
                                     optional: true,
@@ -823,8 +854,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                     let span = Span::new(left.actual_start as u32, bracket_end as u32);
                     left = ParsedExpr::with_end(
+                        self.arena,
                         Expression::MemberExpression(MemberExpression {
-                            object: arena.alloc(left.expr),
+                            object: left.expr,
                             property: arena.alloc(index),
                             computed: true,
                             optional: false,
@@ -844,11 +876,12 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                     // TSInstantiationExpression + CallExpression → CallExpression with typeArguments
                     let (callee, type_arguments) = match left.expr {
                         Expression::TSInstantiationExpression(inst) => {
-                            (inst.expression, Some(inst.type_arguments))
+                            (inst.expression, Some(inst.type_arguments.clone()))
                         }
-                        other => (&*arena.alloc(other), None),
+                        other => (other, None),
                     };
                     left = ParsedExpr::with_end(
+                        self.arena,
                         Expression::CallExpression(CallExpression {
                             callee,
                             type_arguments,
@@ -878,11 +911,12 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                         // TSInstantiationExpression + TaggedTemplate → TaggedTemplate with typeArguments
                         let (tag, type_arguments) = match left.expr {
                             Expression::TSInstantiationExpression(inst) => {
-                                (inst.expression, Some(inst.type_arguments))
+                                (inst.expression, Some(inst.type_arguments.clone()))
                             }
-                            other => (&*arena.alloc(other), None),
+                            other => (other, None),
                         };
                         left = ParsedExpr::with_end(
+                            self.arena,
                             Expression::TaggedTemplateExpression(TaggedTemplateExpression {
                                 tag,
                                 type_arguments,
@@ -911,9 +945,10 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                     let span = Span::new(left.actual_start as u32, op_end as u32);
                     left = ParsedExpr::with_end(
+                        self.arena,
                         Expression::UpdateExpression(UpdateExpression {
                             operator,
-                            argument: arena.alloc(left.expr),
+                            argument: left.expr,
                             prefix: false,
                             span,
                         }),
@@ -964,7 +999,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     ) -> Result<Expression<'arena>, ParseError> {
         let atom = self.parse_heritage_atom()?;
         let parsed = self.parse_postfix_expression(atom, SubscriptMode::ClassHeritage)?;
-        Ok(parsed.expr)
+        Ok(parsed.expr.clone())
     }
 
     /// Parse the primary atom of an `extends` clause (acorn's `parseExprAtom` with
@@ -983,22 +1018,27 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         {
             self.advance()?; // consume 'async'
             return Ok(ParsedExpr::from_expr(
+                self.arena,
                 self.parse_async_function_expression(start)?,
             ));
         }
         match self.current_kind() {
-            TokenKind::Keyword(KeywordKind::New) => {
-                Ok(ParsedExpr::from_expr(self.parse_new_expression()?))
-            }
-            TokenKind::Keyword(KeywordKind::Class) => {
-                Ok(ParsedExpr::from_expr(self.parse_class_expression()?))
-            }
-            TokenKind::Keyword(KeywordKind::Function) => {
-                Ok(ParsedExpr::from_expr(self.parse_function_expression()?))
-            }
-            TokenKind::Keyword(KeywordKind::Import) => {
-                Ok(ParsedExpr::from_expr(self.parse_import_or_meta_property()?))
-            }
+            TokenKind::Keyword(KeywordKind::New) => Ok(ParsedExpr::from_expr(
+                self.arena,
+                self.parse_new_expression()?,
+            )),
+            TokenKind::Keyword(KeywordKind::Class) => Ok(ParsedExpr::from_expr(
+                self.arena,
+                self.parse_class_expression()?,
+            )),
+            TokenKind::Keyword(KeywordKind::Function) => Ok(ParsedExpr::from_expr(
+                self.arena,
+                self.parse_function_expression()?,
+            )),
+            TokenKind::Keyword(KeywordKind::Import) => Ok(ParsedExpr::from_expr(
+                self.arena,
+                self.parse_import_or_meta_property()?,
+            )),
             _ => {
                 let parsed = self.parse_primary_expression_with_end()?;
                 // Reject a top-level (unparenthesized) arrow: `class C extends (a) => b {}`.
@@ -1091,7 +1131,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 let literal = self.parse_number_or_bigint_literal()?;
                 let end = self.current_pos().1;
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Literal(literal),
                     end,
                 ))
@@ -1100,7 +1140,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 let (start, end) = self.current_pos();
                 let cooked = self.extract_string_cooked();
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Literal(Literal {
                         value: LiteralValue::String(cooked),
                         span: Span::new(start as u32, end as u32),
@@ -1112,7 +1152,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 let (start, end) = self.current_pos();
                 let symbol = self.intern_identifier();
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Identifier(Identifier::simple(
                         symbol,
                         Span::new(start as u32, end as u32),
@@ -1125,12 +1165,12 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             TokenKind::Keyword(KeywordKind::Await) if self.await_is_identifier() => {
                 self.parse_await_identifier_reference()
             }
-            TokenKind::BraceOpen => Ok(ParsedExpr::from_expr(self.parse_object_expression()?)),
-            TokenKind::BracketOpen => Ok(ParsedExpr::from_expr(self.parse_array_expression()?)),
+            TokenKind::BraceOpen => Ok(ParsedExpr::from_expr(self.arena,self.parse_object_expression()?)),
+            TokenKind::BracketOpen => Ok(ParsedExpr::from_expr(self.arena,self.parse_array_expression()?)),
             TokenKind::Keyword(KeywordKind::True) => {
                 let (start, end) = self.current_pos();
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Literal(Literal {
                         value: LiteralValue::Boolean(true),
                         span: Span::new(start as u32, end as u32),
@@ -1141,7 +1181,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             TokenKind::Keyword(KeywordKind::False) => {
                 let (start, end) = self.current_pos();
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Literal(Literal {
                         value: LiteralValue::Boolean(false),
                         span: Span::new(start as u32, end as u32),
@@ -1152,7 +1192,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             TokenKind::Keyword(KeywordKind::Null) => {
                 let (start, end) = self.current_pos();
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Literal(Literal {
                         value: LiteralValue::Null,
                         span: Span::new(start as u32, end as u32),
@@ -1163,7 +1203,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             TokenKind::Keyword(KeywordKind::This) => {
                 let (start, end) = self.current_pos();
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::ThisExpression(ThisExpression {
                         span: Span::new(start as u32, end as u32),
                     }),
@@ -1173,7 +1213,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             TokenKind::Keyword(KeywordKind::Super) => {
                 let (start, end) = self.current_pos();
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Super(Super {
                         span: Span::new(start as u32, end as u32),
                     }),
@@ -1184,11 +1224,11 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 // Could be: arrow function `() => ...` or parenthesized expression `(expr)`
                 self.parse_paren_expression_with_end()
             }
-            TokenKind::DotDotDot => Ok(ParsedExpr::from_expr(self.parse_spread_element()?)),
+            TokenKind::DotDotDot => Ok(ParsedExpr::from_expr(self.arena,self.parse_spread_element()?)),
             TokenKind::NoSubstitutionTemplate | TokenKind::TemplateHead => {
                 // Untagged template literal (a primary expression): invalid escapes
                 // are a syntax error (only tagged templates tolerate them).
-                Ok(ParsedExpr::from_expr(self.parse_template_literal(false)?))
+                Ok(ParsedExpr::from_expr(self.arena,self.parse_template_literal(false)?))
             }
             TokenKind::Slash | TokenKind::SlashEquals => {
                 // In expression context, `/` or `/=` starts a regex literal, not division
@@ -1244,7 +1284,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 self.had_line_terminator = self.lexer.had_line_terminator();
                 self.collect_comments()?;
 
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::RegexLiteral(RegexLiteral {
                         pattern_span,
                         flags_span,
@@ -1258,7 +1298,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 // Private identifier as standalone expression (for brand check: #field in obj)
                 let private_id = self.parse_private_identifier()?;
                 let end = private_id.span.end_usize();
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::PrivateIdentifier(private_id),
                     end,
                 ))
@@ -1287,7 +1327,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                 let (start, end) = self.current_pos();
                 let symbol = self.intern(self.current_value());
                 self.advance()?;
-                Ok(ParsedExpr::with_end(
+                Ok(ParsedExpr::with_end(self.arena,
                     Expression::Identifier(Identifier::simple(
                         symbol,
                         Span::new(start as u32, end as u32),
@@ -1313,7 +1353,10 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     fn parse_paren_expression_with_end(&mut self) -> Result<ParsedExpr<'arena>, ParseError> {
         // Check if this looks like an arrow function by scanning ahead
         if self.is_arrow_function_start() {
-            return Ok(ParsedExpr::from_expr(self.parse_arrow_function()?));
+            return Ok(ParsedExpr::from_expr(
+                self.arena,
+                self.parse_arrow_function()?,
+            ));
         }
 
         // Parse as grouped expression: (expr)
@@ -1345,10 +1388,14 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         // get the paren-inclusive span) but carries the explicit wrapper node.
         if is_jsdoc_cast {
             let cast = Expression::JsdocCast(JsdocCast {
-                inner: self.alloc(parsed.expr),
+                inner: parsed.expr,
                 span: Span::new(paren_start as u32, paren_end as u32),
             });
-            return Ok(ParsedExpr::with_bounds(cast, paren_start, paren_end));
+            return Ok(ParsedExpr::with_bounds(
+                self.alloc(cast),
+                paren_start,
+                paren_end,
+            ));
         }
         Ok(ParsedExpr::with_bounds(parsed.expr, paren_start, paren_end))
     }
@@ -1404,7 +1451,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
         Ok(Expression::TSTypeAssertion(TSTypeAssertion {
             type_annotation: arena.alloc(type_annotation),
-            expression: arena.alloc(parsed.expr),
+            expression: parsed.expr,
             span: Span::new(start as u32, end),
         }))
     }
@@ -1424,12 +1471,13 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         let end = type_args.span.end;
 
         let inst = TSInstantiationExpression {
-            expression: self.alloc(left.expr),
+            expression: left.expr,
             type_arguments: type_args,
             span: Span::new(left.actual_start as u32, end),
         };
 
         Ok(ParsedExpr::with_end(
+            self.arena,
             Expression::TSInstantiationExpression(inst),
             end as usize,
         ))
@@ -1464,7 +1512,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
         Ok(Expression::UnaryExpression(UnaryExpression {
             operator,
-            argument: self.alloc(parsed.expr),
+            argument: parsed.expr,
             prefix: true,
             span: Span::new(start as u32, end),
         }))
@@ -1492,7 +1540,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
         Ok(Expression::UnaryExpression(UnaryExpression {
             operator,
-            argument: self.alloc(parsed.expr),
+            argument: parsed.expr,
             prefix: true,
             span: Span::new(start as u32, end),
         }))
@@ -1510,7 +1558,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         let end = parsed.actual_end as u32;
 
         Ok(Expression::AwaitExpression(AwaitExpression {
-            argument: self.alloc(parsed.expr),
+            argument: parsed.expr,
             span: Span::new(start as u32, end),
         }))
     }
@@ -1523,6 +1571,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         let symbol = self.intern("await");
         self.advance()?;
         Ok(ParsedExpr::with_end(
+            self.arena,
             Expression::Identifier(Identifier::simple(
                 symbol,
                 Span::new(start as u32, end as u32),
@@ -1538,7 +1587,6 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     /// - `yield value` yields the given value
     /// - `yield* iterable` delegates to another generator/iterable
     fn parse_yield_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let arena = self.arena;
         let (start, yield_end) = self.current_pos();
         self.advance()?; // consume 'yield'
 
@@ -1557,7 +1605,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             // yield* requires an argument
             let parsed = self.parse_expression_bp(BP_YIELD)?;
             let end = parsed.actual_end as u32;
-            (Some(&*arena.alloc(parsed.expr)), end)
+            (Some(parsed.expr), end)
         } else if self.can_insert_semicolon() || matches!(self.current_kind(), TokenKind::Eof) {
             // No argument - yield with no value
             (None, yield_end as u32)
@@ -1565,7 +1613,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             // Parse the argument
             let parsed = self.parse_expression_bp(BP_YIELD)?;
             let end = parsed.actual_end as u32;
-            (Some(&*arena.alloc(parsed.expr)), end)
+            (Some(parsed.expr), end)
         } else {
             // No argument
             (None, yield_end as u32)
@@ -1654,7 +1702,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
         Ok(Expression::UpdateExpression(UpdateExpression {
             operator,
-            argument: self.alloc(parsed.expr),
+            argument: parsed.expr,
             prefix: true,
             span: Span::new(start as u32, end),
         }))
@@ -1701,22 +1749,22 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             let (start, _) = self.current_pos();
             self.advance()?; // consume 'async'
             let expr = self.parse_async_function_expression(start)?;
-            ParsedExpr::from_expr(expr)
+            ParsedExpr::from_expr(self.arena, expr)
         } else {
             match self.current_kind() {
                 TokenKind::Keyword(KeywordKind::New) => {
                     let nested = self.parse_new_expression()?;
-                    ParsedExpr::from_expr(nested)
+                    ParsedExpr::from_expr(self.arena, nested)
                 }
                 TokenKind::Keyword(KeywordKind::Function) => {
                     // Function expression: `new function() {}`
                     let expr = self.parse_function_expression()?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 }
                 TokenKind::Keyword(KeywordKind::Class) => {
                     // Class expression: `new class {}`
                     let expr = self.parse_class_expression()?;
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 }
                 TokenKind::Keyword(KeywordKind::Import) => {
                     // `new import.meta()` — `import.meta` is a MetaProperty (a
@@ -1729,7 +1777,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                     if matches!(expr, Expression::ImportExpression(_)) {
                         return Err(self.error_msg_at("Cannot use new with import()", import_start));
                     }
-                    ParsedExpr::from_expr(expr)
+                    ParsedExpr::from_expr(self.arena, expr)
                 }
                 _ => {
                     // We use primary + postfix parsing but stop before call expressions
@@ -1755,8 +1803,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
                     // actual_start covers a parenthesized callee's `(` (`new (a()).b`)
                     let span = Span::new(callee.actual_start as u32, prop_end as u32);
                     callee = ParsedExpr::with_end(
+                        self.arena,
                         Expression::MemberExpression(MemberExpression {
-                            object: arena.alloc(callee.expr),
+                            object: callee.expr,
                             property: arena.alloc(Expression::Identifier(Identifier::simple(
                                 name,
                                 Span::new(prop_start as u32, prop_end as u32),
@@ -1776,8 +1825,9 @@ impl<'a, 'arena> Parser<'a, 'arena> {
 
                     let span = Span::new(callee.actual_start as u32, bracket_end as u32);
                     callee = ParsedExpr::with_end(
+                        self.arena,
                         Expression::MemberExpression(MemberExpression {
-                            object: arena.alloc(callee.expr),
+                            object: callee.expr,
                             property: arena.alloc(index),
                             computed: true,
                             optional: false,
@@ -1840,7 +1890,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             };
 
         Ok(Expression::NewExpression(NewExpression {
-            callee: arena.alloc(callee.expr),
+            callee: callee.expr,
             type_arguments,
             arguments,
             span: Span::new(start as u32, end),

--- a/crates/tsv_ts/src/parser/statement/class.rs
+++ b/crates/tsv_ts/src/parser/statement/class.rs
@@ -152,18 +152,17 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             return Err(self.error_expected_after("'class'", "decorator"));
         }
 
-        // Build the class node, mutate it (attach decorators + extend the span to
-        // cover them), then arena-box it — `ClassExpression` is boxed into the
-        // `Expression` enum, so a shared `&'arena` ref can't be mutated in place.
-        let mut class = self.parse_class_expression_node()?;
-        class.decorators = if decorators.is_empty() {
-            None
-        } else {
-            Some(decorators.into_bump_slice())
-        };
-        // Extend the span to cover the leading decorators.
-        class.span = Span::new(start as u32, class.span.end);
-        Ok(Expression::ClassExpression(self.alloc(class)))
+        let mut expr = self.parse_class_expression()?;
+        if let Expression::ClassExpression(class) = &mut expr {
+            class.decorators = if decorators.is_empty() {
+                None
+            } else {
+                Some(decorators.into_bump_slice())
+            };
+            // Extend the span to cover the leading decorators.
+            class.span = Span::new(start as u32, class.span.end);
+        }
+        Ok(expr)
     }
 
     /// Parse a list of decorators: `@dec1 @dec2 ...`
@@ -239,14 +238,6 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     /// - They appear in expression position
     /// - No `declare` field
     pub fn parse_class_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let class = self.parse_class_expression_node()?;
-        Ok(Expression::ClassExpression(self.alloc(class)))
-    }
-
-    /// Parse a class expression into a raw `ClassExpression` node (not yet wrapped
-    /// in `Expression`). The decorated-class path mutates the node before boxing it,
-    /// which the shared `&'arena` ref in `Expression::ClassExpression` can't support.
-    fn parse_class_expression_node(&mut self) -> Result<ClassExpression<'arena>, ParseError> {
         let (start, _) = self.current_pos();
 
         // Consume 'class' keyword
@@ -296,7 +287,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         let body = self.parse_class_body(false)?;
         let end = body.span.end;
 
-        Ok(ClassExpression {
+        Ok(Expression::ClassExpression(ClassExpression {
             decorators: None,
             id,
             super_class,
@@ -306,7 +297,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             r#abstract: false,
             type_parameters,
             span: Span::new(start as u32, end),
-        })
+        }))
     }
 
     /// Inner function that returns the ClassDeclaration directly

--- a/crates/tsv_ts/src/parser/statement/class.rs
+++ b/crates/tsv_ts/src/parser/statement/class.rs
@@ -152,17 +152,18 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             return Err(self.error_expected_after("'class'", "decorator"));
         }
 
-        let mut expr = self.parse_class_expression()?;
-        if let Expression::ClassExpression(class) = &mut expr {
-            class.decorators = if decorators.is_empty() {
-                None
-            } else {
-                Some(decorators.into_bump_slice())
-            };
-            // Extend the span to cover the leading decorators.
-            class.span = Span::new(start as u32, class.span.end);
-        }
-        Ok(expr)
+        // Build the class node, mutate it (attach decorators + extend the span to
+        // cover them), then arena-box it — `ClassExpression` is boxed into the
+        // `Expression` enum, so a shared `&'arena` ref can't be mutated in place.
+        let mut class = self.parse_class_expression_node()?;
+        class.decorators = if decorators.is_empty() {
+            None
+        } else {
+            Some(decorators.into_bump_slice())
+        };
+        // Extend the span to cover the leading decorators.
+        class.span = Span::new(start as u32, class.span.end);
+        Ok(Expression::ClassExpression(self.alloc(class)))
     }
 
     /// Parse a list of decorators: `@dec1 @dec2 ...`
@@ -238,6 +239,14 @@ impl<'a, 'arena> Parser<'a, 'arena> {
     /// - They appear in expression position
     /// - No `declare` field
     pub fn parse_class_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let class = self.parse_class_expression_node()?;
+        Ok(Expression::ClassExpression(self.alloc(class)))
+    }
+
+    /// Parse a class expression into a raw `ClassExpression` node (not yet wrapped
+    /// in `Expression`). The decorated-class path mutates the node before boxing it,
+    /// which the shared `&'arena` ref in `Expression::ClassExpression` can't support.
+    fn parse_class_expression_node(&mut self) -> Result<ClassExpression<'arena>, ParseError> {
         let (start, _) = self.current_pos();
 
         // Consume 'class' keyword
@@ -287,7 +296,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
         let body = self.parse_class_body(false)?;
         let end = body.span.end;
 
-        Ok(Expression::ClassExpression(ClassExpression {
+        Ok(ClassExpression {
             decorators: None,
             id,
             super_class,
@@ -297,7 +306,7 @@ impl<'a, 'arena> Parser<'a, 'arena> {
             r#abstract: false,
             type_parameters,
             span: Span::new(start as u32, end),
-        }))
+        })
     }
 
     /// Inner function that returns the ClassDeclaration directly

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -744,6 +744,14 @@ and the extra pointer-chases that size-minimization adds on hot traversal paths
 cost more than the cache-density they buy. (The arena allocation itself is the
 win; the node *layout* favors traversal locality over byte size.)
 
+The fat inline nodes carry no by-value-return penalty in the parser, either: each
+node is built in the arena and threaded up the recursive descent **by reference**
+(the expression parser's transient `ParsedExpr` wrapper holds an `&'arena
+Expression`, not the node), so the recursion moves pointers regardless of node
+size. The two concerns are decoupled — node *layout* is tuned for the format
+traversal, while the parse-time recursion cost is paid in pointer moves — so a fat
+inline variant is not a reason to box it.
+
 **Rationale vs flat/indexed:** Flat/indexed layouts (index arrays, à la Zig's
 `MultiArrayList`) were benchmarked early in development and were slower —
 traversal replaced direct pointer/reference access with index lookups, and a


### PR DESCRIPTION
Some substantial gains to the parser here. Increases traversal costs for printing but total wall clock is a win.