### PR TITLE
perf: avoid heap allocations for svelte printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ tsv has no config that changes its formatting style behavior, and none will be a
   [#156](https://github.com/fuzdev/tsv/pull/156), [#165](https://github.com/fuzdev/tsv/pull/165),
   [#199](https://github.com/fuzdev/tsv/pull/199), [#200](https://github.com/fuzdev/tsv/pull/200),
   [#205](https://github.com/fuzdev/tsv/pull/205), [#208](https://github.com/fuzdev/tsv/pull/208),
-  [#209](https://github.com/fuzdev/tsv/pull/209))
+  [#209](https://github.com/fuzdev/tsv/pull/209), [#210](https://github.com/fuzdev/tsv/pull/210))
 
 ## 0.1.0
 

--- a/crates/tsv_lang/src/doc/arena.rs
+++ b/crates/tsv_lang/src/doc/arena.rs
@@ -16,6 +16,7 @@ use std::cell::RefCell;
 use crate::config::TAB_WIDTH;
 use crate::printing::visual_width;
 
+use super::DocBuf;
 use super::types::{
     DocContext, DocText, GroupId, LineKind, Mode, TEXT_WIDTH_HAS_NEWLINE, TEXT_WIDTH_NOT_COMPUTED,
 };
@@ -842,8 +843,8 @@ impl DocArena {
             IsolatedGroup(DocId),
             IfBreakFlat(DocId),
             IndentIfBreakContents(DocId),
-            Concat(Vec<DocId>),
-            Fill(Vec<DocId>),
+            Concat(DocBuf),
+            Fill(DocBuf),
             WithContext(DocId, DocContext),
             LineSuffix(DocId),
             BreakParent,
@@ -873,11 +874,11 @@ impl DocArena {
                 DocNode::IndentIfBreak { contents, .. } => Info::IndentIfBreakContents(*contents),
                 DocNode::Concat(range) => {
                     let children = self.children.borrow();
-                    Info::Concat(range.resolve(&children).to_vec())
+                    Info::Concat(DocBuf::from_slice(range.resolve(&children)))
                 }
                 DocNode::Fill(range) => {
                     let children = self.children.borrow();
-                    Info::Fill(range.resolve(&children).to_vec())
+                    Info::Fill(DocBuf::from_slice(range.resolve(&children)))
                 }
                 DocNode::WithContext { doc, context } => Info::WithContext(*doc, context.clone()),
                 DocNode::LineSuffix(inner) => Info::LineSuffix(*inner),
@@ -923,9 +924,9 @@ impl DocArena {
                     } else {
                         let kids = {
                             let children = self.children.borrow();
-                            expanded_states.resolve(&children).to_vec()
+                            DocBuf::from_slice(expanded_states.resolve(&children))
                         };
-                        let new_kids: Vec<DocId> =
+                        let new_kids: DocBuf =
                             kids.into_iter().map(|kid| self.remove_lines(kid)).collect();
                         self.alloc_children(&new_kids)
                     };
@@ -944,13 +945,13 @@ impl DocArena {
             Info::IfBreakFlat(flat_doc) => self.remove_lines(flat_doc),
             Info::IndentIfBreakContents(contents) => self.remove_lines(contents),
             Info::Concat(kids) => {
-                let flattened: Vec<DocId> =
+                let flattened: DocBuf =
                     kids.into_iter().map(|kid| self.remove_lines(kid)).collect();
                 self.concat(&flattened)
             }
             Info::Fill(kids) => {
                 // Fill becomes regular concat when flattened
-                let flattened: Vec<DocId> =
+                let flattened: DocBuf =
                     kids.into_iter().map(|kid| self.remove_lines(kid)).collect();
                 self.concat(&flattened)
             }

--- a/crates/tsv_svelte/src/printer/attributes.rs
+++ b/crates/tsv_svelte/src/printer/attributes.rs
@@ -276,7 +276,7 @@ impl<'a> Printer<'a> {
         if raw.contains('\n') {
             // Split at newlines, join with literalline to preserve literal newlines
             // and trigger will_break on the attribute group
-            let line_docs: Vec<DocId> = raw
+            let line_docs: DocBuf = raw
                 .split('\n')
                 .map(|part| d.text_owned(part.to_string()))
                 .collect();
@@ -492,7 +492,7 @@ impl<'a> Printer<'a> {
     //
 
     /// Build Doc parts for modifiers: `|mod1|mod2`
-    fn build_modifiers_doc(&self, modifiers: &[&str]) -> Vec<DocId> {
+    fn build_modifiers_doc(&self, modifiers: &[&str]) -> DocBuf {
         modifiers
             .iter()
             .flat_map(|m| [self.d().text("|"), self.d().text_owned((*m).to_string())])
@@ -533,7 +533,7 @@ impl<'a> Printer<'a> {
         &self,
         expr: &Expression<'_>,
         tag_span: Option<Span>,
-    ) -> Vec<DocId> {
+    ) -> DocBuf {
         let expr_content = self.build_expression_content_with_comments(expr, tag_span);
 
         // For expressions with internal group structure, keep them hugged with the braces.
@@ -588,19 +588,19 @@ impl<'a> Printer<'a> {
             self.wrap_in_block_structure(expr_content)
         };
 
-        vec![d.text("="), inner]
+        smallvec![d.text("="), inner]
     }
 
     /// Build expression content with leading/trailing comments
     ///
-    /// Returns a Vec<DocId> containing: leading comments + expression doc + trailing comments
+    /// Returns the doc parts: leading comments + expression doc + trailing comments
     fn build_expression_content_with_comments(
         &self,
         expr: &Expression<'_>,
         tag_span: Option<Span>,
-    ) -> Vec<DocId> {
+    ) -> DocBuf {
         // Collect leading comments
-        let mut leading_comments = Vec::new();
+        let mut leading_comments: DocBuf = DocBuf::new();
         if let Some(span) = tag_span {
             let expr_start = expr.span().start;
             for comment in comments_in_range(self.comments, span.start + 1, expr_start) {
@@ -611,7 +611,7 @@ impl<'a> Printer<'a> {
         let expr_doc = self.build_expression_doc_for_attribute(expr);
 
         // Collect trailing comments
-        let mut trailing_comments = Vec::new();
+        let mut trailing_comments: DocBuf = DocBuf::new();
         if let Some(span) = tag_span {
             let expr_end = expr.span().end;
             for comment in comments_in_range(self.comments, expr_end, span.end - 1) {
@@ -627,7 +627,7 @@ impl<'a> Printer<'a> {
     }
 
     /// Wrap expression content in block structure: `{\n\texpr\n}`
-    fn wrap_in_block_structure(&self, expr_content: Vec<DocId>) -> DocId {
+    fn wrap_in_block_structure(&self, expr_content: DocBuf) -> DocId {
         let d = self.d();
         let content = d.concat(&expr_content);
         let softline = d.softline();
@@ -660,7 +660,7 @@ impl<'a> Printer<'a> {
         &self,
         expr: &Expression<'_>,
         tag_span: Option<Span>,
-    ) -> Vec<DocId> {
+    ) -> DocBuf {
         let d = self.d();
         // For SequenceExpression, use the bare (no parens) version for getter/setter syntax
         if let Expression::SequenceExpression(seq) = expr {
@@ -672,7 +672,7 @@ impl<'a> Printer<'a> {
             if let Some(span) = tag_span {
                 let last_end = seq.expressions[seq.expressions.len() - 1].span().end;
                 if tsv_lang::has_comments_in_range(self.comments, span.start + 1, last_end) {
-                    return vec![
+                    return smallvec![
                         d.text("="),
                         self.build_bind_sequence_with_comments_doc(seq, span),
                     ];
@@ -682,7 +682,7 @@ impl<'a> Printer<'a> {
             let len = seq.expressions.len();
 
             // Build items: each expression with trailing comma (except last)
-            let items: Vec<DocId> = seq
+            let items: DocBuf = seq
                 .expressions
                 .iter()
                 .enumerate()
@@ -703,7 +703,10 @@ impl<'a> Printer<'a> {
 
             // Bare block structure (shared with every other bind value): flat
             // `={getter, setter}`, broken `={\n\tgetter,\n\tsetter\n}`.
-            return vec![d.text("="), self.wrap_in_block_structure(vec![items_doc])];
+            return smallvec![
+                d.text("="),
+                self.wrap_in_block_structure(smallvec![items_doc])
+            ];
         }
 
         // For bind: directives, BinaryExpression should use block structure (not hugging).
@@ -742,7 +745,7 @@ impl<'a> Printer<'a> {
     ) -> DocId {
         let d = self.d();
         let bytes = self.source.as_bytes();
-        let mut content: Vec<DocId> = Vec::new();
+        let mut content: DocBuf = DocBuf::new();
 
         // Leading comments between `{` and the first operand. A line or multi-line
         // block comment ends in a hardline, forcing the outer `{ }` to break — but
@@ -764,7 +767,7 @@ impl<'a> Printer<'a> {
             }
         }
 
-        let mut items: Vec<DocId> = Vec::new();
+        let mut items: DocBuf = DocBuf::new();
         for (i, sub_expr) in seq.expressions.iter().enumerate() {
             if i > 0 {
                 let prev_end = seq.expressions[i - 1].span().end;
@@ -823,9 +826,9 @@ impl<'a> Printer<'a> {
         &self,
         expr: &Expression<'_>,
         tag_span: Option<Span>,
-    ) -> Vec<DocId> {
+    ) -> DocBuf {
         let expr_content = self.build_expression_content_with_comments(expr, tag_span);
-        vec![
+        smallvec![
             self.d().text("="),
             self.wrap_in_block_structure(expr_content),
         ]

--- a/crates/tsv_svelte/src/printer/mod.rs
+++ b/crates/tsv_svelte/src/printer/mod.rs
@@ -30,6 +30,7 @@ use crate::ast::internal::{self, FragmentNode};
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::rc::Rc;
+use tsv_lang::doc::DocBuf;
 use tsv_lang::doc::arena::{DocArena, DocId};
 use tsv_lang::{
     Comment, EmbedContext, INDENT, OutputBuffer, SharedInterner, SymbolResolver, TAB_WIDTH,
@@ -578,7 +579,7 @@ impl<'a> Printer<'a> {
 
         // Split at `format-ignore` ranges and at interior section comments (both rare); most
         // templates are one segment.
-        let mut out: Vec<DocId> = Vec::new();
+        let mut out: DocBuf = DocBuf::new();
         let mut seg_start = 0;
         let mut i = 0;
         while i < nodes.len() {

--- a/crates/tsv_svelte/src/printer/nodes/element_doc.rs
+++ b/crates/tsv_svelte/src/printer/nodes/element_doc.rs
@@ -14,6 +14,7 @@
 use crate::ast::internal::{self, FragmentNode};
 use crate::printer::Printer;
 use crate::printer::text::TextAnalysis;
+use smallvec::smallvec;
 use tsv_lang::comments_in_range;
 use tsv_lang::doc::{DocBuf, arena::DocId};
 use tsv_lang::{Span, SymbolResolver, SymbolToU32};
@@ -766,7 +767,7 @@ impl<'a> Printer<'a> {
             element.open_tag_end,
             true,
         );
-        let mut parts = vec![d.text("<"), d.symbol(tag_sym)];
+        let mut parts: DocBuf = smallvec![d.text("<"), d.symbol(tag_sym)];
         parts.extend(space_attrs);
         parts.push(d.text(">"));
 
@@ -842,7 +843,7 @@ impl<'a> Printer<'a> {
                 // Build doc with properly indented content
                 // Each line of formatted content goes on its own line with indent
                 let lines: Vec<&str> = formatted.trim_end().lines().collect();
-                let mut content_lines = Vec::with_capacity(lines.len() * 2);
+                let mut content_lines: DocBuf = DocBuf::with_capacity(lines.len() * 2);
                 for line in lines {
                     content_lines.push(d.hardline());
                     if !line.is_empty() {

--- a/crates/tsv_svelte/src/printer/nodes/element_ws_sensitive_doc.rs
+++ b/crates/tsv_svelte/src/printer/nodes/element_ws_sensitive_doc.rs
@@ -13,6 +13,7 @@ use super::blocks_doc::{EACH_BLOCK_OPEN, ELSE_IF_BLOCK_OPEN, IF_BLOCK_OPEN};
 use super::helpers::each_expr_comment_end;
 use crate::ast::internal::{self, Fragment, FragmentNode};
 use crate::printer::Printer;
+use smallvec::smallvec;
 use tsv_lang::doc::{DocBuf, arena::DocId};
 use tsv_lang::{SymbolResolver, SymbolToU32};
 
@@ -373,7 +374,7 @@ impl<'a> Printer<'a> {
 
         let body_doc = self.build_whitespace_sensitive_content_doc(block.consequent.nodes);
 
-        let mut parts = vec![d.text(IF_BLOCK_OPEN), expr_doc, d.text("}"), body_doc];
+        let mut parts: DocBuf = smallvec![d.text(IF_BLOCK_OPEN), expr_doc, d.text("}"), body_doc];
 
         if let Some(alt) = &block.alternate {
             self.build_ws_sensitive_if_alternate(alt, &mut parts);
@@ -384,7 +385,7 @@ impl<'a> Printer<'a> {
     }
 
     /// Build if alternate (else/else-if) for whitespace-sensitive context.
-    fn build_ws_sensitive_if_alternate(&self, alt: &Fragment<'_>, parts: &mut Vec<DocId>) {
+    fn build_ws_sensitive_if_alternate(&self, alt: &Fragment<'_>, parts: &mut DocBuf) {
         let d = self.d();
 
         // Check if this can be flattened to {:else if ...}
@@ -425,7 +426,7 @@ impl<'a> Printer<'a> {
             false,
         );
 
-        let mut opening = vec![d.text(EACH_BLOCK_OPEN), expr_doc];
+        let mut opening: DocBuf = smallvec![d.text(EACH_BLOCK_OPEN), expr_doc];
 
         if let Some(context) = &block.context {
             opening.push(d.text(" as "));
@@ -462,7 +463,7 @@ impl<'a> Printer<'a> {
         let body_doc = self.build_whitespace_sensitive_content_doc(block.body.nodes);
 
         let opening_concat = d.concat(&opening);
-        let mut parts = vec![opening_concat, body_doc];
+        let mut parts: DocBuf = smallvec![opening_concat, body_doc];
 
         if let Some(fallback) = &block.fallback {
             let fallback_doc = self.build_whitespace_sensitive_content_doc(fallback.nodes);

--- a/crates/tsv_svelte/src/printer/nodes/helpers.rs
+++ b/crates/tsv_svelte/src/printer/nodes/helpers.rs
@@ -6,9 +6,11 @@
 
 use crate::ast::internal::{EachBlock, FragmentNode};
 use crate::printer::Printer;
+use smallvec::smallvec;
 use tsv_lang::Span;
 use tsv_lang::TAB_WIDTH;
 use tsv_lang::comments_in_range;
+use tsv_lang::doc::DocBuf;
 use tsv_lang::doc::arena::DocId;
 use tsv_lang::source_scan::find_char_skipping_comments;
 use tsv_ts::Expression;
@@ -180,7 +182,7 @@ impl<'a> Printer<'a> {
     /// runs to end of line, so the following token drops to the next line to avoid
     /// swallowing it). Empty doc when the range holds no comments.
     fn build_pattern_leading_comments(&self, start: u32, end: u32) -> DocId {
-        let docs: Vec<DocId> = comments_in_range(self.comments, start, end)
+        let docs: DocBuf = comments_in_range(self.comments, start, end)
             .map(|c| self.build_leading_js_comment_doc(c))
             .collect();
         self.d().concat(&docs)
@@ -190,7 +192,7 @@ impl<'a> Printer<'a> {
     /// ` /* … */` (inline, leading space); a line comment as ` // …` + `hardline`. Empty
     /// doc when the range holds no comments.
     fn build_pattern_trailing_comments(&self, start: u32, end: u32) -> DocId {
-        let docs: Vec<DocId> = comments_in_range(self.comments, start, end)
+        let docs: DocBuf = comments_in_range(self.comments, start, end)
             .map(|c| self.build_trailing_js_comment_doc(c))
             .collect();
         self.d().concat(&docs)
@@ -343,7 +345,7 @@ impl<'a> Printer<'a> {
         entries: &[(u32, u32, DocId)],
     ) -> DocId {
         let d = self.d();
-        let mut parts = vec![d.text("{")];
+        let mut parts: DocBuf = smallvec![d.text("{")];
         if entries.is_empty() {
             // Empty pattern stays tight (`{}`), but preserve a dangling comment.
             parts.push(self.build_pattern_leading_comments(span_start + 1, span_end - 1));
@@ -378,7 +380,7 @@ impl<'a> Printer<'a> {
         span_end: u32,
     ) -> DocId {
         let d = self.d();
-        let mut parts = vec![d.text("[")];
+        let mut parts: DocBuf = smallvec![d.text("[")];
         let mut prev_end = span_start + 1; // past `[`
         for (i, elem) in elements.iter().enumerate() {
             if i == 0 {
@@ -526,7 +528,7 @@ impl<'a> Printer<'a> {
         let expr_end = expr.span().end;
 
         // Build docs for leading comments (between span_start and expression start)
-        let leading_docs: Vec<DocId> = comments_in_range(self.comments, span_start, expr_start)
+        let leading_docs: DocBuf = comments_in_range(self.comments, span_start, expr_start)
             .map(|c| self.build_leading_js_comment_doc(c))
             .collect();
 
@@ -548,7 +550,7 @@ impl<'a> Printer<'a> {
             tsv_ts::build_expression_doc_with_comments(d, expr, &self.ts_inputs(), &embed);
 
         // Build docs for trailing comments (between expression end and span_end)
-        let trailing_docs: Vec<DocId> = comments_in_range(self.comments, expr_end, span_end)
+        let trailing_docs: DocBuf = comments_in_range(self.comments, expr_end, span_end)
             .map(|c| self.build_trailing_js_comment_doc(c))
             .collect();
 
@@ -584,7 +586,7 @@ impl<'a> Printer<'a> {
         let expr_end = expr.span().end;
 
         // Build docs for leading comments
-        let leading_docs: Vec<DocId> = comments_in_range(self.comments, span_start, expr_start)
+        let leading_docs: DocBuf = comments_in_range(self.comments, span_start, expr_start)
             .map(|c| self.build_leading_js_comment_doc(c))
             .collect();
 
@@ -622,7 +624,7 @@ impl<'a> Printer<'a> {
         };
 
         // Build docs for trailing comments
-        let trailing_docs: Vec<DocId> = comments_in_range(self.comments, expr_end, span_end)
+        let trailing_docs: DocBuf = comments_in_range(self.comments, expr_end, span_end)
             .map(|c| self.build_trailing_js_comment_doc(c))
             .collect();
 
@@ -663,14 +665,15 @@ impl<'a> Printer<'a> {
     /// `build_const_init_doc`).
     pub(super) fn concat_with_surrounding_comments(
         &self,
-        leading_docs: Vec<DocId>,
+        leading_docs: DocBuf,
         expr_doc: DocId,
-        trailing_docs: Vec<DocId>,
+        trailing_docs: DocBuf,
     ) -> DocId {
         if leading_docs.is_empty() && trailing_docs.is_empty() {
             expr_doc
         } else {
-            let mut parts = Vec::with_capacity(leading_docs.len() + 1 + trailing_docs.len());
+            let mut parts: DocBuf =
+                DocBuf::with_capacity(leading_docs.len() + 1 + trailing_docs.len());
             parts.extend(leading_docs);
             parts.push(expr_doc);
             parts.extend(trailing_docs);

--- a/crates/tsv_svelte/src/printer/nodes/tags_doc.rs
+++ b/crates/tsv_svelte/src/printer/nodes/tags_doc.rs
@@ -5,10 +5,11 @@
 
 use crate::ast::internal;
 use crate::printer::Printer;
+use smallvec::smallvec;
 use tsv_lang::Span;
 use tsv_lang::comments_in_range;
-use tsv_lang::doc::GroupId;
 use tsv_lang::doc::arena::DocId;
+use tsv_lang::doc::{DocBuf, GroupId};
 use tsv_ts::Expression;
 
 // Opening-tag literals whose `.len()` locates the embedded expression past the
@@ -162,7 +163,7 @@ impl<'a> Printer<'a> {
         let expr_start = expr.span().start;
         let expr_end = expr.span().end;
 
-        let leading_docs: Vec<DocId> = comments_in_range(self.comments, span_start, expr_start)
+        let leading_docs: DocBuf = comments_in_range(self.comments, span_start, expr_start)
             .map(|c| self.build_leading_js_comment_doc(c))
             .collect();
 
@@ -175,7 +176,7 @@ impl<'a> Printer<'a> {
         let expr_doc =
             tsv_ts::build_expression_doc_with_comments(d, expr, &self.ts_inputs(), &embed);
 
-        let trailing_docs: Vec<DocId> = comments_in_range(self.comments, expr_end, span_end)
+        let trailing_docs: DocBuf = comments_in_range(self.comments, expr_end, span_end)
             .map(|c| self.build_trailing_js_comment_doc(c))
             .collect();
 
@@ -199,7 +200,7 @@ impl<'a> Printer<'a> {
             return d.text("{@debug}");
         }
 
-        let mut parts: Vec<DocId> = vec![d.text("{@debug ")];
+        let mut parts: DocBuf = smallvec![d.text("{@debug ")];
         // Track position as we emit content, starting after the "{@debug" keyword.
         let mut last_end = tag.span.start + DEBUG_TAG_OPEN.len() as u32;
 

--- a/crates/tsv_svelte/src/printer/script_style.rs
+++ b/crates/tsv_svelte/src/printer/script_style.rs
@@ -7,7 +7,7 @@
 use crate::ast::internal;
 use crate::printer::Printer;
 use tsv_lang::TAB_WIDTH;
-use tsv_lang::doc::{self, arena::DocId};
+use tsv_lang::doc::{self, DocBuf, arena::DocId};
 
 impl<'a> Printer<'a> {
     /// Format a Script tag
@@ -234,7 +234,7 @@ impl<'a> Printer<'a> {
         attributes: &[internal::AttributeNode<'_>],
     ) -> (DocId, bool) {
         let d = self.d();
-        let mut parts = Vec::with_capacity(attributes.len() * 2);
+        let mut parts: DocBuf = DocBuf::with_capacity(attributes.len() * 2);
         let mut has_multiline = false;
         for attr in attributes {
             parts.push(d.line());


### PR DESCRIPTION
Like #208 and #209 but for Svelte.