### PR TITLE
perf(experiment): add mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +103,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -258,6 +274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +293,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mio"
@@ -498,6 +532,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +710,7 @@ dependencies = [
  "argh",
  "bumpalo",
  "futures-util",
+ "mimalloc",
  "serde",
  "serde_json",
  "similar",
@@ -695,6 +736,7 @@ dependencies = [
 name = "tsv_ffi"
 version = "0.1.0"
 dependencies = [
+ "mimalloc",
  "serde_json",
  "tsv_arena",
  "tsv_css",
@@ -729,6 +771,7 @@ dependencies = [
 name = "tsv_napi"
 version = "0.1.0"
 dependencies = [
+ "mimalloc",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,10 @@ thiserror = "2"
 unicode-ident = "1.0"
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
+# EXPERIMENTAL (perf A/B only): drop-in global allocator. Off by default —
+# pulled in solely behind each native crate's optional `mimalloc` feature
+# (tsv_debug, tsv_ffi, tsv_napi). Native-only; no WASM build references it.
+mimalloc = "0.1.52"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/tsv_debug/Cargo.toml
+++ b/crates/tsv_debug/Cargo.toml
@@ -24,6 +24,14 @@ thiserror.workspace = true
 similar = "2.7"
 futures-util.workspace = true
 tempfile = "3"
+# Experimental perf A/B — see [features].
+mimalloc = { workspace = true, optional = true }
+
+[features]
+# EXPERIMENTAL: swap in mimalloc as the global allocator (off by default). Used
+# to A/B the `profile` command — `cargo run --release -p tsv_debug --features
+# mimalloc -- profile ...` vs the default build.
+mimalloc = ["dep:mimalloc"]
 
 [lints]
 workspace = true

--- a/crates/tsv_debug/src/main.rs
+++ b/crates/tsv_debug/src/main.rs
@@ -8,6 +8,13 @@ mod test262;
 
 use std::process::ExitCode;
 
+// EXPERIMENTAL perf A/B (off by default): swap the global allocator for mimalloc
+// behind the `mimalloc` feature. Setting it in this binary crate routes every
+// allocation in the linked workspace crates (parser/printer) through mimalloc.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// The single exit point: dispatch the subcommand and map its outcome to a
 /// process exit code. Every command threads its decision back here as a
 /// [`cli::CliError`] instead of calling `std::process::exit` directly.

--- a/crates/tsv_ffi/Cargo.toml
+++ b/crates/tsv_ffi/Cargo.toml
@@ -19,6 +19,8 @@ tsv_css = { workspace = true }
 # re-enables it.
 tsv_arena = { workspace = true }
 serde_json.workspace = true
+# Experimental perf A/B — see the `mimalloc` feature below.
+mimalloc = { workspace = true, optional = true }
 
 [features]
 # Default build — both halves: the full libtsv_ffi the bench perf rows load and
@@ -31,6 +33,10 @@ format = ["tsv_arena/format"]
 # tsv_parse_<lang> + tsv_parse_internal_<lang> exports plus the public-AST/JSON
 # convert layer they serialize through.
 parse = ["tsv_ts/convert", "tsv_css/convert", "tsv_svelte/convert"]
+# EXPERIMENTAL: swap in mimalloc as the global allocator (off by default).
+# Build the bench's native FFI lib with it via `cargo build -p tsv_ffi --release
+# --features mimalloc`, then re-run `deno task bench:deno:run`.
+mimalloc = ["dep:mimalloc"]
 
 # FFI requires unsafe code. Cargo replaces the whole [lints] table on
 # override (no partial inherit), so the workspace lints are re-declared

--- a/crates/tsv_ffi/src/lib.rs
+++ b/crates/tsv_ffi/src/lib.rs
@@ -17,6 +17,14 @@
 
 #![allow(unsafe_code)]
 
+// EXPERIMENTAL perf A/B (off by default): route every allocation through
+// mimalloc behind the `mimalloc` feature. Set in this cdylib root, it covers the
+// parser/printer allocations the bench native row measures through the FFI
+// boundary.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::panic;
 use std::slice;
 

--- a/crates/tsv_napi/Cargo.toml
+++ b/crates/tsv_napi/Cargo.toml
@@ -20,6 +20,8 @@ tsv_css = { workspace = true }
 tsv_arena = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
+# Experimental perf A/B — see the `mimalloc` feature below.
+mimalloc = { workspace = true, optional = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
@@ -38,6 +40,10 @@ default = ["format", "parse"]
 # Pulls the reusable doc arena (`tsv_arena::with_doc_arena`, which pulls tsv_lang).
 format = ["tsv_arena/format"]
 parse = ["tsv_ts/convert", "tsv_css/convert", "tsv_svelte/convert"]
+# EXPERIMENTAL: swap in mimalloc as the global allocator (off by default).
+# Build the bench's native addon with it via `cargo build -p tsv_napi --release
+# --features mimalloc`, then re-run `deno task bench:node:run`.
+mimalloc = ["dep:mimalloc"]
 
 # N-API generates unsafe code, exactly like the FFI crate. Cargo replaces the
 # whole [lints] table on override (no partial inherit), so the workspace lints

--- a/crates/tsv_napi/src/lib.rs
+++ b/crates/tsv_napi/src/lib.rs
@@ -17,6 +17,14 @@
 //! `tsv_ffi` / `tsv_wasm`).
 
 use napi_derive::napi;
+
+// EXPERIMENTAL perf A/B (off by default): route every allocation through
+// mimalloc behind the `mimalloc` feature. Set in this cdylib root, it covers the
+// parser/printer allocations the Node/Bun bench native row measures.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // Per-thread reusable arenas live in the shared `tsv_arena` crate (used by both
 // native bindings — see its module docs for the reuse rationale + soundness).
 use tsv_arena::with_ast_arena;


### PR DESCRIPTION
Testing what it could look like to integrate [mimalloc](https://crates.io/crates/mimalloc) for performance reasons.

benefits:

- native speed, about +3.5% parsing and +3% formatting
- N-API, about +4% parsing and +3.5% formatting
- no WASM

costs:

- adds a C compiler dependency to the project - I'm mostly stuck on this point
- increases binary size +160 KB
- adds the `mimalloc` dep and also `libmimalloc-sys`

The C compiler requirement is something that unlocks other things for tsv, but closes the door on being a simple, pure Rust project. I'm not ready to make that call yet, but this can be revisited.