### PR TITLE
perf: add `talc` wasm allocator dep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1033,6 +1033,7 @@ Higher-fidelity models (attached comments, trivia tokens) may be needed for IDE/
 - `unicode-segmentation` — Grapheme clustering for visual width measurement
 - `unicode-width` — Character display width (CJK, zero-width)
 - `bumpalo` — Bump arena for the internal AST (and, via the `tsv_arena` crate, the bindings' per-thread `reset()` reuse — `tsv_ffi`/`tsv_napi`/`tsv_wasm`)
+- `talc` — WASM global allocator (`tsv_wasm` only, wasm32-only target dep): pure-Rust `no_std` allocator replacing std's default dlmalloc; the `WasmGrowAndExtend` source keeps the warm instance's linear-memory high-water at dlmalloc parity. Pulls `lock_api` + `allocator-api2` (+ `scopeguard`) into the wasm32 graph only; native builds unaffected
 - `napi` / `napi-derive` / `napi-build` — N-API bindings for `tsv_napi` (Node/Bun native addon; tsv-scoped carve-out)
 
 ## Canonical References

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "argh"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +270,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +571,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "talc"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a5888b3189a89207eea4190e74387b5db3150d213f84186cac637dcd55259d"
+dependencies = [
+ "allocator-api2",
+ "lock_api",
 ]
 
 [[package]]
@@ -769,6 +800,7 @@ name = "tsv_wasm"
 version = "0.1.0"
 dependencies = [
  "js-sys",
+ "talc",
  "tsv_arena",
  "tsv_css",
  "tsv_discover",

--- a/crates/tsv_wasm/CLAUDE.md
+++ b/crates/tsv_wasm/CLAUDE.md
@@ -134,7 +134,7 @@ require dual updates.
 
 ## Files
 
-- `src/lib.rs` — WASM bindings (`lang_bindings!` macro + typed extern types)
+- `src/lib.rs` — WASM bindings (`lang_bindings!` macro + typed extern types) + the wasm32-gated talc `#[global_allocator]`
 - `types/tsv_ast.d.ts` — Hand-maintained TS types, bundled into the parse-capable packages
 - `npm/cli.js` — The `tsv` bin shipped in `@fuzdev/tsv_wasm` — mirrors `tsv_cli`'s contract (flags, exit codes, traversal); `node:util` `parseArgs`, zero deps
 - `README_format.md` — Shipped as `README.md` in `@fuzdev/tsv_format_wasm` (copied by `patch_npm_package.ts`)

--- a/crates/tsv_wasm/Cargo.toml
+++ b/crates/tsv_wasm/Cargo.toml
@@ -64,5 +64,13 @@ wasm-bindgen = "0.2"
 # graph (measurably faster materialization).
 js-sys = { version = "0.3", optional = true }
 
+# WASM-only global allocator (see the `#[global_allocator]` in lib.rs): a
+# pure-Rust no_std allocator replacing std's default dlmalloc on wasm32. Its
+# transitive deps (`lock_api`, `allocator-api2`, `scopeguard`) are tiny
+# pure-Rust no_std crates. Native builds are untouched — the target cfg-gate
+# keeps all of it out of every non-wasm dependency graph.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+talc = "5.0.4"
+
 [lints]
 workspace = true

--- a/crates/tsv_wasm/src/lib.rs
+++ b/crates/tsv_wasm/src/lib.rs
@@ -27,6 +27,21 @@ use tsv_arena::with_ast_arena;
 #[cfg(feature = "format")]
 use tsv_arena::with_doc_arena;
 
+// WASM global allocator: talc replaces std's default dlmalloc on wasm32. The
+// format path is allocation-heavy (doc IR, output string, memo vecs) and
+// dlmalloc's grow/memcpy behavior is the measured allocation wall there; talc
+// is a pure-Rust no_std allocator tuned for WebAssembly. The `WasmGrowAndExtend`
+// source (vs the default `WasmGrowAndClaim`) extends one contiguous heap on
+// `memory.grow` instead of claiming fragmented new ones — it holds the
+// long-lived reset()-reuse instance's linear-memory high-water at dlmalloc
+// parity, where the claim-source fragments it. Single-threaded WASM only
+// (`TalcSyncCell::new_wasm` panics under atomics, which tsv never builds
+// with); native builds keep the system allocator via the target gate.
+#[cfg(target_arch = "wasm32")]
+#[global_allocator]
+static ALLOCATOR: talc::cell::TalcSyncCell<talc::wasm::WasmGrowAndExtend, talc::wasm::WasmBinning> =
+    talc::cell::TalcSyncCell::new_wasm(talc::wasm::WasmGrowAndExtend::new());
+
 fn err(e: impl ToString) -> JsError {
     JsError::new(&e.to_string())
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -654,7 +654,7 @@ A `format-ignore` / `prettier-ignore` comment suppresses formatting of the const
 
 ## Allocation & Memory
 
-tsv runs on the system allocator — no `#[global_allocator]`, no alternative-allocator dependency. The performance posture is structural: each layer avoids allocation by design rather than allocating faster. (An allocator swap remains an open lever; it is a dependency decision, not an architectural one.)
+Native tsv runs on the system allocator — no `#[global_allocator]`, no alternative-allocator dependency. The one exception is WebAssembly: `tsv_wasm` sets a wasm32-gated `#[global_allocator]` to [talc](https://github.com/SFBdragon/talc) (its `WasmGrowAndExtend` source), replacing std's default dlmalloc — the WASM format path is allocation-bound enough that the allocator itself was a measured wall, and the extend source holds the long-lived instance's linear-memory high-water at dlmalloc parity. The performance posture is otherwise structural: each layer avoids allocation by design rather than allocating faster.
 
 **Lexing — spans, not strings.** Tokens store `u32` byte offsets (`start`, `end`) into the source, never slices or copies — `Token` is a 16-byte POD the byte cursor (`bytes: &[u8]` + `position`) emits and the parser unpacks in registers. The exception is deliberate: a string literal allocates its decoded value only when it actually contains escape sequences, held **out-of-band on the lexer** (`Lexer::decoded`, drained via `take_decoded`) so the per-token `Token` stays pointer-free. Comments are spans too — the token carries a `content_start` and the `Comment` node a `content_span`, recovered from source on demand and never copied.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -270,7 +270,8 @@ Notes:
   corpus-dependent and can hit a corpus that barely exercises the changed path
   *harder* than one that leans on it, and it does not touch the WASM-format wall.
   Allocation count is the right gate for the
-  **WASM-format** wall (dlmalloc memcpys on every heap growth, §6) *only when
+  **WASM-format** wall (allocator work in linear memory is costlier than
+  native malloc, §6) *only when
   storage stays cache-dense*, and a churn signal for native — never a substitute
   for the format-phase wall A/B itself (`tsv_debug profile` native rate with
   parse as the machine-state control, plus `wasm_format_probe`). Confirm the
@@ -322,9 +323,10 @@ noise floor before trusting any delta; on this workload the floor is roughly
 
 The tools above measure the native Rust side. Allocation *counts* are
 target-independent (heaptrack reads the same on either), but WASM *wall-time* is
-not: `@fuzdev/tsv_format_wasm` runs on dlmalloc, which memcpys on every heap
-growth, so an allocation-count win can move WASM format time even when the same
-change is a wash on native glibc. The full `deno task bench` is too coarse to
+not: `@fuzdev/tsv_format_wasm` runs on talc (the wasm32 `#[global_allocator]` in
+`tsv_wasm`; std's default dlmalloc before the swap), whose per-call cost profile
+differs from native glibc — so an allocation-count win can move WASM format time
+even when the same change is a wash on native. The full `deno task bench` is too coarse to
 see those single-digit-% moves; `benches/js/diagnostics/wasm_format_probe.ts` resolves
 them.
 

--- a/scripts/validate_artifacts.ts
+++ b/scripts/validate_artifacts.ts
@@ -55,25 +55,24 @@ function file_size(path: URL): number | null {
 const VARIANTS = ['format', 'parse', 'all'] as const;
 const TARGETS = ['npm', 'deno'] as const;
 
-// Measured 2026-07-03 (the Svelte comment-island attach no longer re-parses
-// its emitted bytes into a `serde_json::Value` — the skeleton recorder walks
-// the wire tree structurally — so the last production `from_slice::<Value>`
-// left the convert path and serde_json's `Value` deserializer tree-shakes out
-// of the `parse` feature entirely): parse 1,120,110 B (−97 KB); all
-// 2,529,672 B (npm == deno, identical `.wasm`). format 2,302,533 B — ≈flat
-// (−10 KB from span-identity identifier emission + printer gates), since the
-// deleted machinery was convert-only. Bounds recentered ±8%.
+// Measured 2026-07-04 (two size cuts landed together: the wasm32 feature
+// baseline moved to `+simd128,+multivalue` — the multivalue return ABI
+// shrinks the pair-return-dense parse path most, ≈−9% parse / ≈−4.4%
+// format+all — and talc replaced std's default dlmalloc as the wasm32 global
+// allocator, dropping a few more KB per bundle): format 2,178,122 B; parse
+// 1,015,388 B; all 2,401,628 B (npm == deno, identical `.wasm`). Bounds
+// recentered ±8%.
 const BOUNDS = {
-	format: { min: 2_115_000, max: 2_490_000 },
-	parse: { min: 1_030_000, max: 1_210_000 },
-	all: { min: 2_325_000, max: 2_735_000 },
+	format: { min: 2_005_000, max: 2_350_000 },
+	parse: { min: 934_000, max: 1_097_000 },
+	all: { min: 2_210_000, max: 2_595_000 },
 };
 
 // all = format + parse. `all − format` is the parse feature (parser convert
-// path; measured 227,139 B — down from 312,547 B when it still carried the
+// path; measured 223,506 B — down from 312,547 B when it still carried the
 // comment-island round-trip's `Value` deserialization machinery); `all −
 // parse` is the format feature (printers + doc builder, dropped from the
-// parse-only build at link time; measured 1,409,562 B, ≈unchanged — the
+// parse-only build at link time; measured 1,386,240 B, ≈unchanged — the
 // gate-health signal). A delta near zero means a feature gate broke.
 const DELTAS = {
 	format: { min: 209_000, max: 245_000 }, // all − format


### PR DESCRIPTION
Gives about a 3% format speed boost and a little size off the binary - https://github.com/SFBdragon/talc