### PR TITLE
refactor: simplify given trailing_comma none

### DIFF
--- a/crates/tsv_ts/src/printer/calls/arg_comments.rs
+++ b/crates/tsv_ts/src/printer/calls/arg_comments.rs
@@ -669,40 +669,6 @@ impl<'a> PartitionedComments<'a> {
         }
     }
 
-    /// Emit the **last** argument's same-line trailing comments split around its source
-    /// comma position: before-comma blocks — and, when the source has no comma, every
-    /// block — trail the arg; after-comma blocks stay past where the comma was
-    /// (`b /* c */`, the tsv divergence prettier relocates to `b /* c */`); the same-line
-    /// line comment follows via `line_suffix`. No trailing comma is emitted
-    /// (trailingComma: 'none').
-    ///
-    /// The last-argument analogue of [`emit_trailing_comments_around_comma`]: that one
-    /// assumes a real separating comma exists (a non-last gap) and drops a before-comma
-    /// block if none is found, whereas the last arg has no trailing comma, so a block
-    /// with no source comma must still precede the closing paren. Shared by the
-    /// member-chain and `new` last-arg paths so the split rule lives in one place.
-    pub fn emit_last_arg_trailing_around_comma(&self, parts: &mut DocBuf, printer: &Printer<'_>) {
-        let d = printer.d();
-        let comma_pos = find_comma_pos(printer.source, self.start, self.end);
-        for comment in &self.trailing_block {
-            if comma_pos.is_none_or(|cp| is_comment_before_comma(comment, cp)) {
-                parts.push(d.text(" "));
-                parts.push(printer.build_comment_doc(comment));
-            }
-        }
-        if let Some(cp) = comma_pos {
-            for comment in &self.trailing_block {
-                if is_comment_after_comma(comment, cp) {
-                    parts.push(d.text(" "));
-                    parts.push(printer.build_comment_doc(comment));
-                }
-            }
-        }
-        for comment in &self.trailing_line {
-            parts.push(printer.build_trailing_line_comment_doc(comment));
-        }
-    }
-
     /// Emit own-line ("leading") comments each on its own line (hardline before),
     /// with no comma. The bare dangling-comment emission shared by every last-argument
     /// path (no trailing comma precedes them — trailingComma: 'none') and by comma-less
@@ -722,19 +688,19 @@ impl<'a> PartitionedComments<'a> {
         }
     }
 
-    /// Emit a last argument's complete trailing-comment region: same-line comments split
-    /// around the source comma position when any are present (via
-    /// [`emit_last_arg_trailing_around_comma`]), then own-line dangling comments (via
-    /// [`emit_dangling_comments`]). No trailing comma is emitted (trailingComma: 'none').
+    /// Emit a last argument's complete trailing-comment region: same-line comments (via
+    /// [`emit_trailing_comments`]), then own-line dangling comments (via
+    /// [`emit_dangling_comments`]). No trailing comma is emitted (trailingComma: 'none'),
+    /// so a same-line block trails the arg in source order whether it sat before or after
+    /// the source comma — the last arg needs no split around the never-emitted comma.
     ///
     /// The last-argument counterpart to [`Printer::open_inter_arg_gap`] (the non-last
     /// gap): shared by the `new` and member-chain last-arg paths so the ordering lives in
-    /// one place. (`call_formatting` keeps its own same-line handling — it defers
-    /// after-comma blocks into a separate doc and feeds `force_expansion` — and so calls
-    /// only `emit_dangling_comments` directly.)
+    /// one place. (`call_formatting` keeps its own same-line loop, feeding
+    /// `force_expansion`, and calls only [`emit_dangling_comments`] directly.)
     pub fn emit_last_arg_comments(&self, parts: &mut DocBuf, printer: &Printer<'_>) {
         if self.has_trailing_line() || self.has_trailing_block() {
-            self.emit_last_arg_trailing_around_comma(parts, printer);
+            self.emit_trailing_comments(parts, printer);
         }
         self.emit_dangling_comments(parts, printer);
     }

--- a/crates/tsv_ts/src/printer/calls/arg_comments.rs
+++ b/crates/tsv_ts/src/printer/calls/arg_comments.rs
@@ -699,9 +699,9 @@ impl<'a> PartitionedComments<'a> {
     /// one place. (`call_formatting` keeps its own same-line loop, feeding
     /// `force_expansion`, and calls only [`emit_dangling_comments`] directly.)
     pub fn emit_last_arg_comments(&self, parts: &mut DocBuf, printer: &Printer<'_>) {
-        if self.has_trailing_line() || self.has_trailing_block() {
-            self.emit_trailing_comments(parts, printer);
-        }
+        // `emit_trailing_comments` already no-ops when there are no trailing comments,
+        // so no presence guard is needed.
+        self.emit_trailing_comments(parts, printer);
         self.emit_dangling_comments(parts, printer);
     }
 

--- a/crates/tsv_ts/src/printer/calls/arg_wrapping.rs
+++ b/crates/tsv_ts/src/printer/calls/arg_wrapping.rs
@@ -122,23 +122,15 @@ pub(super) enum CallBreakStyle {
 /// that if the callee contains hardlines (e.g., multiline array), they don't
 /// force the arguments to break. The args make their own flat/break decision.
 ///
-/// `post_comma` is emitted immediately after the last arg (before the closing `)`), so
-/// an after-comma trailing comment stays past where the comma was; pass `d.empty()` when
-/// there is none. No trailing comma is emitted (trailingComma: 'none').
+/// No trailing comma is emitted (trailingComma: 'none').
 #[inline]
-fn wrap_call(
-    d: &DocArena,
-    callee: DocId,
-    args: DocId,
-    post_comma: DocId,
-    style: CallBreakStyle,
-) -> DocId {
+fn wrap_call(d: &DocArena, callee: DocId, args: DocId, style: CallBreakStyle) -> DocId {
     match style {
         CallBreakStyle::Soft => d.concat(&[
             callee,
             d.group(d.concat(&[
                 d.text("("),
-                d.indent_softline(d.concat(&[args, post_comma])),
+                d.indent_softline(args),
                 d.softline(),
                 d.text(")"),
             ])),
@@ -146,7 +138,7 @@ fn wrap_call(
         CallBreakStyle::Hard => d.concat(&[
             callee,
             d.text("("),
-            d.indent(d.concat(&[d.hardline(), args, post_comma])),
+            d.indent(d.concat(&[d.hardline(), args])),
             d.hardline(),
             d.text(")"),
         ]),
@@ -157,39 +149,14 @@ fn wrap_call(
 /// Uses soft breaks so the call can collapse to a single line if it fits
 #[inline]
 pub(crate) fn wrap_call_with_soft_breaks(d: &DocArena, callee: DocId, args: DocId) -> DocId {
-    wrap_call(d, callee, args, d.empty(), CallBreakStyle::Soft)
+    wrap_call(d, callee, args, CallBreakStyle::Soft)
 }
 
 /// Wrap arguments in an expanded call expression: `callee(\n\targs,\n)`
 /// Uses hard breaks to force multi-line layout
 #[inline]
 pub(crate) fn wrap_call_with_hard_breaks(d: &DocArena, callee: DocId, args: DocId) -> DocId {
-    wrap_call(d, callee, args, d.empty(), CallBreakStyle::Hard)
-}
-
-/// Like [`wrap_call_with_soft_breaks`], but emits `post_comma` after the last arg so an
-/// after-comma trailing comment is preserved past where the comma was (`b /* c */`; no
-/// trailing comma, trailingComma: 'none').
-#[inline]
-pub(super) fn wrap_call_with_soft_breaks_suffix(
-    d: &DocArena,
-    callee: DocId,
-    args: DocId,
-    post_comma: DocId,
-) -> DocId {
-    wrap_call(d, callee, args, post_comma, CallBreakStyle::Soft)
-}
-
-/// Like [`wrap_call_with_hard_breaks`], but emits `post_comma` after the last arg (no
-/// trailing comma; trailingComma: 'none').
-#[inline]
-pub(super) fn wrap_call_with_hard_breaks_suffix(
-    d: &DocArena,
-    callee: DocId,
-    args: DocId,
-    post_comma: DocId,
-) -> DocId {
-    wrap_call(d, callee, args, post_comma, CallBreakStyle::Hard)
+    wrap_call(d, callee, args, CallBreakStyle::Hard)
 }
 
 /// Wrap arguments with a `will_break` guard: if any arg contains hardlines

--- a/crates/tsv_ts/src/printer/calls/call_formatting.rs
+++ b/crates/tsv_ts/src/printer/calls/call_formatting.rs
@@ -5,9 +5,9 @@
 
 use super::super::{ParenContext, Printer, has_multiline_content};
 use super::arg_comments::{
-    PartitionedComments, any_comment_forces_expansion, find_comma_pos, first_arg_has_any_comments,
+    PartitionedComments, any_comment_forces_expansion, first_arg_has_any_comments,
     has_blank_line_between_args, has_inter_argument_comments, has_trailing_comments_on_args,
-    is_comment_after_comma, last_arg_has_comments, should_force_expansion_for_comments,
+    last_arg_has_comments, should_force_expansion_for_comments,
 };
 use super::arg_predicates::{
     arrow_body_is_call_through_non_null, arrow_has_trailing_param_comments,
@@ -1214,10 +1214,6 @@ fn build_call_with_arg_comments(
     // line). Injected after `(` in the force-expansion wrap below.
     let mut paren_line_prefix_parts: DocBuf = DocBuf::new();
     let mut force_expansion = false;
-    // Block comment trailing the last arg after its source comma — preserved past
-    // where the comma was (no trailing comma; prettier relocates before; see
-    // conformance_prettier.md).
-    let mut last_after_comma: DocBuf = DocBuf::new();
 
     for (i, arg) in call.arguments.iter().enumerate() {
         // Handle leading comments before first argument
@@ -1377,28 +1373,21 @@ fn build_call_with_arg_comments(
             );
 
             // Trailing comments after the last arg, before the closing paren, in
-            // source order: same-line block comments first (split around the source
-            // comma), then the same-line line comment (after the comma, via
-            // `line_suffix`), then own-line comments (each on its own line). Emitting
-            // same-line comments before own-line ones — and never dropping a block —
-            // avoids merging consecutive comments onto one line (which reverses their
-            // order) and content loss. The `new`/member-chain last-arg paths do the
-            // same via the shared emit_* helpers; this path keeps its own loop only
-            // for the block comma-split (before- vs after-comma; no trailing comma).
+            // source order: same-line block comments first, then the same-line line
+            // comment (via `line_suffix`), then own-line comments (each on its own
+            // line). Emitting same-line comments before own-line ones — and never
+            // dropping a block — avoids merging consecutive comments onto one line
+            // (which reverses their order) and content loss.
 
-            // (1) Same-line block comments: before-comma blocks trail the arg, after-
-            // comma blocks are preserved past where the comma was (no trailing comma).
-            // Don't force expansion on their own — let width/source newlines decide.
-            // e.g., fn({short} /* c */) stays inline, fn({long...} /* c */) expands.
-            let comma_pos = find_comma_pos(printer.source, effective_arg_end, paren_close);
+            // (1) Same-line block comments trail the arg in source order. With no
+            // trailing comma emitted (trailingComma: 'none'), a block that sat after
+            // the source comma simply trails the arg past where the comma was — no
+            // split around the never-emitted comma. Don't force expansion on their own
+            // — let width/source newlines decide: fn({short} /* c */) stays inline,
+            // fn({long...} /* c */) expands.
             for comment in &pc.trailing_block {
-                if comma_pos.is_some_and(|cp| is_comment_after_comma(comment, cp)) {
-                    last_after_comma.push(d.text(" "));
-                    last_after_comma.push(printer.build_comment_doc(comment));
-                } else {
-                    arg_parts.push(d.text(" "));
-                    arg_parts.push(printer.build_comment_doc(comment));
-                }
+                arg_parts.push(d.text(" "));
+                arg_parts.push(printer.build_comment_doc(comment));
             }
 
             // (2) Same-line line comment after the last arg, via `line_suffix`.
@@ -1449,25 +1438,8 @@ fn build_call_with_arg_comments(
             callee,
             d.text("("),
             d.concat(&paren_line_prefix_parts),
-            d.group_break(d.concat(&[
-                d.indent(d.concat(&[d.hardline(), arg_doc, d.concat(&last_after_comma)])),
-                d.hardline(),
-            ])),
+            d.group_break(d.concat(&[d.indent(d.concat(&[d.hardline(), arg_doc])), d.hardline()])),
             d.text(")"),
-        ]));
-    }
-
-    // After-comma block comment on the last arg: preserved past where the comma
-    // was (soft-break wrapper; no trailing comma, trailingComma: 'none').
-    if !last_after_comma.is_empty() {
-        return Some(d.concat(&[
-            callee,
-            d.group(d.concat(&[
-                d.text("("),
-                d.indent_softline(d.concat(&[arg_doc, d.concat(&last_after_comma)])),
-                d.softline(),
-                d.text(")"),
-            ])),
         ]));
     }
 

--- a/crates/tsv_ts/src/printer/calls/chain_args.rs
+++ b/crates/tsv_ts/src/printer/calls/chain_args.rs
@@ -642,10 +642,10 @@ fn build_chain_args_force_expand(
                 arg_end,
                 next_boundary,
             );
-            // Last argument - same-line trailing comments split around the source comma
-            // position (before-comma blocks trail the arg, after-comma blocks + line
-            // stay past it), then own-line dangling comments. No trailing comma
-            // (trailingComma: 'none').
+            // Last argument - same-line trailing comments trail the arg in source order
+            // (a block that sat after the source comma just trails past where the comma
+            // was; a line comment follows via `line_suffix`), then own-line dangling
+            // comments. No trailing comma (trailingComma: 'none').
             pc.emit_last_arg_comments(&mut arg_parts, printer);
         }
     }
@@ -653,8 +653,8 @@ fn build_chain_args_force_expand(
     parts.push(d.text(prefix));
     parts.push(d.concat(&paren_line_prefix_parts));
     // No trailing comma after the last arg (trailingComma: 'none') — the last-arg
-    // comment emit splits same-line comments around the source comma position but
-    // emits no comma, and nothing is appended here.
+    // comment emit trails same-line comments after the arg and emits no comma, so
+    // nothing is appended here.
     parts.push(d.indent(d.concat(&[d.hardline(), d.concat(&arg_parts)])));
     parts.push(d.hardline());
     parts.push(d.text(")"));

--- a/crates/tsv_ts/src/printer/calls/new_expression.rs
+++ b/crates/tsv_ts/src/printer/calls/new_expression.rs
@@ -425,11 +425,11 @@ impl<'a> Printer<'a> {
                         paren_close,
                     );
 
-                    // Same-line trailing comments split around the source comma position
-                    // (after-comma blocks stay past it, `b /* c */` — the tsv divergence —
-                    // and a line comment follows via `line_suffix`), then own-line dangling
-                    // comments. No trailing comma (trailingComma: 'none'). Matches the
-                    // call/member-chain last-arg paths.
+                    // Same-line trailing comments trail the arg in source order (a block
+                    // that sat after the source comma just trails past where the comma was,
+                    // `b /* c */` — the tsv divergence; a line comment follows via
+                    // `line_suffix`), then own-line dangling comments. No trailing comma
+                    // (trailingComma: 'none'). Matches the call/member-chain last-arg paths.
                     pc.emit_last_arg_comments(&mut arg_parts, self);
                 }
             }

--- a/crates/tsv_ts/src/printer/calls/new_expression.rs
+++ b/crates/tsv_ts/src/printer/calls/new_expression.rs
@@ -2,11 +2,9 @@
 //
 // Handles: new Foo(), new Foo(arg1, arg2), new Foo<T>()
 
-use super::arg_comments::{find_comma_pos, is_comment_after_comma};
 use super::arg_wrapping::{
     append_type_args_with_gap_comments, build_args_with_blank_lines, build_empty_args_doc,
-    should_expand_first_arg, try_hug_multiline_template_arg, wrap_call_with_hard_breaks_suffix,
-    wrap_call_with_soft_breaks_suffix,
+    should_expand_first_arg, try_hug_multiline_template_arg, wrap_call_with_soft_breaks,
 };
 use crate::ast::internal;
 use crate::printer::calls::arg_predicates::{
@@ -520,48 +518,26 @@ impl<'a> Printer<'a> {
             }
 
             if let Some(last_doc) = arg_docs.pop() {
-                // Split same-line blocks around the last arg's source comma: before-comma
-                // blocks (and any block when the source has no comma) hug the arg; an
-                // after-comma block is preserved past where the comma was (`b /* c */`; no
-                // trailing comma, trailingComma: 'none').
+                // Same-line blocks trail the last arg in source order. With no trailing
+                // comma emitted (trailingComma: 'none'), a block that sat after the
+                // source comma simply trails the arg past where the comma was
+                // (`b /* c */`) — no split around the never-emitted comma.
                 // No line comments reach this block-only path.
-                let comma_pos = find_comma_pos(self.source, effective_arg_end, new_expr.span.end);
                 let mut last_with_comment: DocBuf = smallvec![last_doc];
-                let mut after_comma = DocBuf::new();
                 for comment in &pc.trailing_block {
-                    if comma_pos.is_some_and(|cp| is_comment_after_comma(comment, cp)) {
-                        after_comma.push(d.text(" "));
-                        after_comma.push(self.build_comment_doc(comment));
-                    } else {
-                        last_with_comment.push(d.text(" "));
-                        last_with_comment.push(self.build_comment_doc(comment));
-                    }
+                    last_with_comment.push(d.text(" "));
+                    last_with_comment.push(self.build_comment_doc(comment));
                 }
                 arg_docs.push(d.concat(&last_with_comment));
-
-                // The after-comma block (if any) is kept past where the comma was via the
-                // wrap's `post_comma` suffix: `b /* c */` (no trailing comma in either
-                // mode; trailingComma: 'none').
-                let post_comma = d.concat(&after_comma);
 
                 // For function composition (multiple callbacks), use hardlines
                 // For simple args, use soft breaks (can stay inline)
                 if is_function_composition_args(new_expr.arguments) {
                     let arg_parts = d.join_doc(arg_docs, d.comma_hardline());
-                    return wrap_call_with_hard_breaks_suffix(
-                        d,
-                        callee_with_types,
-                        arg_parts,
-                        post_comma,
-                    );
+                    return wrap_call_with_hard_breaks(d, callee_with_types, arg_parts);
                 }
                 let arg_parts = d.join_doc(arg_docs, d.comma_line());
-                return wrap_call_with_soft_breaks_suffix(
-                    d,
-                    callee_with_types,
-                    arg_parts,
-                    post_comma,
-                );
+                return wrap_call_with_soft_breaks(d, callee_with_types, arg_parts);
             }
         }
 

--- a/crates/tsv_ts/src/printer/chain/adapter.rs
+++ b/crates/tsv_ts/src/printer/chain/adapter.rs
@@ -110,33 +110,30 @@ impl<'a> ChainPrinter for Printer<'a> {
             return None;
         }
         let d = self.d();
-        // The `[` is the char just before the index region (past `?.` for `?.[`).
-        let bracket_char_pos = inside_start - 1;
-        // `[`→index: a `[`-line comment is pulled onto the `[` line, an own-line one
-        // stays on its own line (blank-preserving), mirroring the computed-key bracket.
-        let (line_prefix, pull_pos) =
-            self.delimiter_line_comment_prefix(bracket_char_pos, prop_start);
-        let mut inner_parts =
-            self.build_leading_comments_multiline_opt(inside_start, prop_start, pull_pos);
-        inner_parts.push(inner);
+        // Build the body (index + any index→`]` trailing comments), then hand it to the
+        // shared bracket-break helper (it owns the `[`→index line-comment prefix and the
+        // break shell, mirroring the computed-key bracket). `[`→index: a `[`-line comment
+        // is pulled onto the `[` line, an own-line one keeps its line (blank-preserving).
         // index→`]`: a same-line comment trails the index, an own-line one keeps its line.
+        let mut body_parts = DocBuf::new();
+        body_parts.push(inner);
         let mut prev = prop_end;
         for comment in comments_in_range(self.comments, prop_end, bracket_end) {
             if self.is_same_line(prev, comment.span.start) {
-                inner_parts.push(d.text(" "));
+                body_parts.push(d.text(" "));
             } else {
-                inner_parts.push(d.hardline());
+                body_parts.push(d.hardline());
             }
-            inner_parts.push(self.build_comment_doc(comment));
+            body_parts.push(self.build_comment_doc(comment));
             prev = comment.span.end;
         }
-        Some(d.group_break(d.concat(&[
-            d.text(open),
-            d.concat(&line_prefix),
-            d.indent_softline(d.concat(&inner_parts)),
-            d.softline(),
-            d.text("]"),
-        ])))
+        // The `[` is the char just before the index region (past `?.` for `?.[`).
+        Some(self.build_bracket_line_comment_break(
+            open,
+            inside_start - 1,
+            prop_start,
+            d.concat(&body_parts),
+        ))
     }
 
     fn get_property_span(&self, expr: &internal::Expression<'_>) -> Span {

--- a/crates/tsv_ts/src/printer/comments/element_comma.rs
+++ b/crates/tsv_ts/src/printer/comments/element_comma.rs
@@ -22,11 +22,12 @@ use tsv_lang::doc::arena::DocId;
 
 /// Trailing comments collected for a list element (property or array element)
 pub(in crate::printer) struct TrailingComments<'a> {
-    /// Block comments that go before the comma
+    /// Block comments emitted in source order, before the emitted comma. A last
+    /// element's after-comma block is included here too: with no trailing comma
+    /// emitted (trailingComma: 'none') the last comma is `d.empty()`, so before- and
+    /// after-comma blocks both trail the element in one run (prettier relocates an
+    /// after-comma block before the comma; see conformance_prettier.md).
     block: SmallVec<[&'a Comment; 2]>,
-    /// Block comments after the comma, preserved in place (last element only —
-    /// prettier relocates these before the comma; see conformance_prettier.md)
-    block_after: SmallVec<[&'a Comment; 2]>,
     /// Line comments that go after the comma (in line_suffix)
     line: SmallVec<[&'a Comment; 2]>,
     /// Position after all trailing comments (for updating prev_end)
@@ -51,7 +52,6 @@ impl<'a> Printer<'a> {
         if !self.has_comments_between(elem_end, upper_bound) {
             return TrailingComments {
                 block: SmallVec::new(),
-                block_after: SmallVec::new(),
                 line: SmallVec::new(),
                 end_pos: elem_end,
             };
@@ -67,7 +67,10 @@ impl<'a> Printer<'a> {
         // Collect same-line trailing comments. A block comment after the comma
         // normally belongs to the next element as leading — except on the LAST
         // element, where it is preserved after the comma (prettier relocates it
-        // before — see conformance_prettier.md §Comment relocation).
+        // before — see conformance_prettier.md §Comment relocation). With no trailing
+        // comma emitted, a last element's after-comma block trails the element in the
+        // same run as its before-comma blocks, so all same-line blocks collect into
+        // one source-ordered `block` (the comma between them is `d.empty()`).
         let all: CommentVec<'_> = comments_in_range(self.comments, elem_end, upper_bound)
             .filter(|c| {
                 self.is_same_line(elem_end, c.span.start)
@@ -77,21 +80,12 @@ impl<'a> Printer<'a> {
             })
             .collect();
 
-        let is_after_comma =
-            |c: &Comment| c.is_block && comma_pos.is_some_and(|comma| c.span.start > comma);
-
-        let block = all
-            .iter()
-            .filter(|c| c.is_block && !is_after_comma(c))
-            .copied()
-            .collect();
-        let block_after = all.iter().filter(|c| is_after_comma(c)).copied().collect();
+        let block = all.iter().filter(|c| c.is_block).copied().collect();
         let line = all.iter().filter(|c| !c.is_block).copied().collect();
         let end_pos = all.last().map_or(elem_end, |c| c.span.end);
 
         TrailingComments {
             block,
-            block_after,
             line,
             end_pos,
         }
@@ -119,11 +113,11 @@ impl<'a> Printer<'a> {
     }
 
     /// Push one element's trailing comments around its `comma` doc, in the order
-    /// that preserves comment position: block comments before the comma, the
-    /// comma, block comments after the comma (last-element case), then line
-    /// comments as a suffix. Shared by the object/array pattern element loops and
-    /// the object-literal loop so this ordering — the comment-position contract —
-    /// can't drift between them.
+    /// that preserves comment position: same-line block comments (source-ordered,
+    /// including a last element's after-comma block since its comma is `d.empty()`),
+    /// the comma, then line comments as a suffix. Shared by the object/array pattern
+    /// element loops and the object-literal loop so this ordering — the
+    /// comment-position contract — can't drift between them.
     pub(in crate::printer) fn push_element_comma_trailing(
         &self,
         parts: &mut DocBuf,
@@ -132,7 +126,6 @@ impl<'a> Printer<'a> {
     ) {
         parts.push(self.build_block_comments_doc(&trailing.block));
         parts.push(comma);
-        parts.push(self.build_block_comments_doc(&trailing.block_after));
         parts.push(self.build_line_comments_suffix_doc(&trailing.line));
     }
 }

--- a/crates/tsv_ts/src/printer/comments/lists.rs
+++ b/crates/tsv_ts/src/printer/comments/lists.rs
@@ -430,6 +430,36 @@ impl<'a> Printer<'a> {
         self.delimiter_line_comment_prefix_impl(delim_pos, first_elem_start, true)
     }
 
+    /// Assemble a computed `[…]` / `?.[…]` (or mapped-type `[K in T]`) that must BREAK
+    /// because a line comment sits in the open→body gap: pull a `[`-line comment onto the
+    /// open line (own-line ones keep their line, blank-preserving), emit `body`, and drop
+    /// `]`. `body` is pre-built by the caller (key/index/interior plus any body→`]`
+    /// trailing comments, per each printer's own rule), so this owns only the shared
+    /// shell. `open` is the emitted bracket text (`[` or `?.[`); `bracket_char` is the
+    /// source position of the `[` glyph (the scan/pull anchor), decoupled from `open` for
+    /// the `?.[` form (`bracket_char + 1` is the first inside-bracket position). Shared by
+    /// the computed-key, computed-member-access, and mapped-type break paths.
+    pub(in crate::printer) fn build_bracket_line_comment_break(
+        &self,
+        open: &'static str,
+        bracket_char: u32,
+        body_start: u32,
+        body: DocId,
+    ) -> DocId {
+        let d = self.d();
+        let (line_prefix, pull_pos) = self.delimiter_line_comment_prefix(bracket_char, body_start);
+        let mut inner =
+            self.build_leading_comments_multiline_opt(bracket_char + 1, body_start, pull_pos);
+        inner.push(body);
+        d.group_break(d.concat(&[
+            d.text(open),
+            d.concat(&line_prefix),
+            d.indent_softline(d.concat(&inner)),
+            d.softline(),
+            d.text("]"),
+        ]))
+    }
+
     fn delimiter_line_comment_prefix_impl(
         &self,
         delim_pos: u32,

--- a/crates/tsv_ts/src/printer/expressions/objects.rs
+++ b/crates/tsv_ts/src/printer/expressions/objects.rs
@@ -906,32 +906,26 @@ impl<'a> Printer<'a> {
         // block to the key). key→`]`: a same-line comment trails the key with a
         // space, an own-line comment keeps its own line. Prettier relocates instead
         // (conformance_prettier.md §Comment relocation).
-        let (bracket_line_prefix, bracket_pull_pos) =
-            self.delimiter_line_comment_prefix(bracket_start, key_start);
-        let mut inner_parts = self.build_leading_comments_multiline_opt(
-            bracket_start + 1,
-            key_start,
-            bracket_pull_pos,
-        );
-        inner_parts.push(key_doc);
+        // Build the body (key + any key→`]` trailing comments) into a buffer; the shared
+        // bracket-break helper owns the `[`→key line-comment prefix and the break shell.
+        let mut body_parts: DocBuf = smallvec![key_doc];
         let mut prev = key_end;
         for comment in comments_in_range(self.comments, key_end, bracket_end) {
             if self.is_same_line(prev, comment.span.start) {
-                inner_parts.push(d.text(" "));
+                body_parts.push(d.text(" "));
             } else {
-                inner_parts.push(d.hardline());
+                body_parts.push(d.hardline());
             }
-            inner_parts.push(self.build_comment_doc(comment));
+            body_parts.push(self.build_comment_doc(comment));
             prev = comment.span.end;
         }
-        let bracket_body = d.concat(&[
-            d.text("["),
-            d.concat(&bracket_line_prefix),
-            d.indent_softline(d.concat(&inner_parts)),
-            d.softline(),
-            d.text("]"),
-        ]);
-        (d.group_break(bracket_body), bracket_end + 1)
+        let bracket = self.build_bracket_line_comment_break(
+            "[",
+            bracket_start,
+            key_start,
+            d.concat(&body_parts),
+        );
+        (bracket, bracket_end + 1)
     }
 
     /// Find the opening `[` bracket between two positions (for computed properties).

--- a/crates/tsv_ts/src/printer/statements/class.rs
+++ b/crates/tsv_ts/src/printer/statements/class.rs
@@ -517,49 +517,7 @@ impl<'a> Printer<'a> {
             if let Some(cont) = preserve {
                 parts.push(cont);
             } else {
-                // Comments before `=` stay before `=` (e.g., `b /* c */ = 1;`)
-                if self.has_comments_between(before_eq, eq_pos) {
-                    parts.push(self.build_inline_comments_between_doc(before_eq, eq_pos));
-                }
-
-                // Comments after `=`
-                if self.has_line_comments_between(eq_pos + 1, value_start) {
-                    // A same-line comment stays inline with `=` (line comment via
-                    // `line_suffix`, so its width never force-breaks a preceding type
-                    // union); own-line comments stay on their own lines (not merged);
-                    // the value is indented on the next line. `= // comment\n      c`.
-                    parts.push(d.text(" ="));
-                    let expr_doc = self.build_expression_doc(value);
-                    self.append_keyword_value_line_comments(
-                        &mut parts,
-                        eq_pos + 1,
-                        value_start,
-                        expr_doc,
-                    );
-                } else {
-                    // Use assignment layout for proper line-breaking (handles
-                    // both no-comment and inline block comment cases).
-                    // Inline block comments are passed as rhs_comments so
-                    // choose_layout still applies (e.g., ternary with binaryish
-                    // test → BreakAfterOperator).
-                    let rhs_comments = self.build_rhs_comments_opt(eq_pos + 1, value_start);
-                    let left_doc = d.concat(&parts);
-                    // An assignment value keeps its parens (`a = (this.a = b);`) —
-                    // built manually like object property values, since the layout
-                    // chooser takes the bare expression
-                    let assignment_doc =
-                        if self.needs_parens(value, super::ParenContext::DefaultValue) {
-                            let value_doc = d.parens(self.build_expression_doc(value));
-                            let value_doc = match rhs_comments {
-                                Some(comments_doc) => d.concat(&[comments_doc, value_doc]),
-                                None => value_doc,
-                            };
-                            d.concat(&[left_doc, d.text(" = "), value_doc])
-                        } else {
-                            self.build_assignment_layout(left_doc, " =", value, false, rhs_comments)
-                        };
-                    parts = smallvec![assignment_doc];
-                }
+                self.build_property_assignment_layout(&mut parts, before_eq, eq_pos, value);
             }
         }
 
@@ -579,6 +537,59 @@ impl<'a> Printer<'a> {
         parts.extend(after);
 
         d.concat(&parts)
+    }
+
+    /// Emit a class property's `= value` layout into `parts` (which already holds the
+    /// property's LHS). The line-comment-before-`=` fast path is handled by the caller;
+    /// this covers before-`=` block comments, a line comment after `=`, and the
+    /// no-comment / inline-block assignment layout.
+    fn build_property_assignment_layout(
+        &self,
+        parts: &mut DocBuf,
+        before_eq: u32,
+        eq_pos: u32,
+        value: &internal::Expression<'_>,
+    ) {
+        let d = self.d();
+        let value_start = value.span().start;
+
+        // Comments before `=` stay before `=` (e.g., `b /* c */ = 1;`)
+        if self.has_comments_between(before_eq, eq_pos) {
+            parts.push(self.build_inline_comments_between_doc(before_eq, eq_pos));
+        }
+
+        // Comments after `=`
+        if self.has_line_comments_between(eq_pos + 1, value_start) {
+            // A same-line comment stays inline with `=` (line comment via
+            // `line_suffix`, so its width never force-breaks a preceding type
+            // union); own-line comments stay on their own lines (not merged);
+            // the value is indented on the next line. `= // comment\n      c`.
+            parts.push(d.text(" ="));
+            let expr_doc = self.build_expression_doc(value);
+            self.append_keyword_value_line_comments(parts, eq_pos + 1, value_start, expr_doc);
+        } else {
+            // Use assignment layout for proper line-breaking (handles
+            // both no-comment and inline block comment cases).
+            // Inline block comments are passed as rhs_comments so
+            // choose_layout still applies (e.g., ternary with binaryish
+            // test → BreakAfterOperator).
+            let rhs_comments = self.build_rhs_comments_opt(eq_pos + 1, value_start);
+            let left_doc = d.concat(&parts[..]);
+            // An assignment value keeps its parens (`a = (this.a = b);`) —
+            // built manually like object property values, since the layout
+            // chooser takes the bare expression
+            let assignment_doc = if self.needs_parens(value, super::ParenContext::DefaultValue) {
+                let value_doc = d.parens(self.build_expression_doc(value));
+                let value_doc = match rhs_comments {
+                    Some(comments_doc) => d.concat(&[comments_doc, value_doc]),
+                    None => value_doc,
+                };
+                d.concat(&[left_doc, d.text(" = "), value_doc])
+            } else {
+                self.build_assignment_layout(left_doc, " =", value, false, rhs_comments)
+            };
+            *parts = smallvec![assignment_doc];
+        }
     }
 
     /// Build a Doc for a method definition

--- a/crates/tsv_ts/src/printer/types/composite.rs
+++ b/crates/tsv_ts/src/printer/types/composite.rs
@@ -678,21 +678,15 @@ impl<'a> Printer<'a> {
         let bracket_leading_line =
             self.has_line_comments_between(bracket_pos + 1, param_name_start);
         if bracket_leading_line {
-            let (bracket_line_prefix, bracket_pull_pos) =
-                self.delimiter_line_comment_prefix(bracket_pos, param_name_start);
-            let mut inner = self.build_leading_comments_multiline_opt(
-                bracket_pos + 1,
+            // The pre-`]` comments are already inside `interior_parts` (built above via
+            // `build_comments_between`), so the shared helper takes the whole interior as
+            // the body and owns only the `[`→key prefix and the break shell.
+            body_parts.push(self.build_bracket_line_comment_break(
+                "[",
+                bracket_pos,
                 param_name_start,
-                bracket_pull_pos,
-            );
-            inner.push(d.concat(&interior_parts));
-            body_parts.push(d.group_break(d.concat(&[
-                d.text("["),
-                d.concat(&bracket_line_prefix),
-                d.indent_softline(d.concat(&inner)),
-                d.softline(),
-                d.text("]"),
-            ])));
+                d.concat(&interior_parts),
+            ));
         } else {
             body_parts.push(d.text("["));
             // Same-line block comments before the key stay inline (`[/* c */ K in T]`).


### PR DESCRIPTION
There's a tradeoff here that removes code that's useless for tsv but helpful for users who want configurable options. I think it's easy enough to add them back in for users who want this, so it's setting a precedent to make tsv smaller and more focused ("precise") but less friendly to customization. Could be revisited.