### PR TITLE
test: fix for yuku segfault

### DIFF
--- a/benches/js/CLAUDE.md
+++ b/benches/js/CLAUDE.md
@@ -1581,7 +1581,10 @@ prettier. This is load-bearing, not cosmetic, on two axes:
   how the oxc WASI row broke. That's the difference from `oxc.ts`/`oxc_wasm.ts`,
   whose two packages genuinely differ. Unlike oxc's wasi binding the wasm package
   declares no `cpu`/`os`, so it installs as an ordinary dep everywhere and needs no
-  force-fetch.
+  force-fetch. The **N-API row is excluded from the conformance surface** — its
+  native binding faults the host process on that corpus's escaped-identifier
+  fixtures (§Known Issues); the wasm row carries the engine there, and both rows run
+  on perf.
 - rsvelte-fmt (native binary) — the other Rust-native Svelte formatter; languages:
   **Svelte only**, and **COVERAGE-ONLY** — measured for what it accepts, never timed.
   See §Coverage-only rows for both decisions.
@@ -1808,6 +1811,24 @@ Implementation: `lib/binary_sizes.ts`
   `serde_wasm_bindgen`-built object graph). The Rust-side parse-vs-write timing
   is measured by `cargo run --release -p tsv_debug -- json_profile <paths>` —
   `wasm_json_probe.ts` covers the end-to-end view including the JS boundary.
+- **The yuku-parser N-API binding SEGFAULTS on long braced-escape identifiers,
+  so its row is conformance-excluded.** An identifier built from a run of braced
+  unicode escapes faults the host process inside the Zig parse call once the decoded
+  identifier passes ~300 bytes — `parse('var _' + '\u{11A01}'.repeat(75) + ';')`
+  crashes, `repeat(74)` throws an ordinary `ParseFailed`. Non-braced escapes
+  (`\uXXXX`) and literal non-ASCII identifiers are unaffected at any length, and so
+  is the wasm binding (the overrun stays inside linear memory; it parses the same
+  inputs cleanly, which is itself a variant-parity divergence — the process dies
+  before `warn_variant_parity` can report it). test262's
+  `language/identifiers/part-unicode-*-{,class-}escaped.js` are exactly this shape,
+  so the conformance corpus kills the whole run mid-preflight; the perf corpus has no
+  such identifiers. A skip list is not a workaround: **which** files of that family
+  fault is heap-layout dependent (a sweep skipping the 17 observed crashers faulted
+  on an 18th that had survived it), so the screen is neither cacheable nor
+  reproducible. Hence the row — not the files — is dropped on that surface
+  (`get_benchmark_tasks`, keyed on `BenchmarkTaskOptions.corpus_kind`), disclosed in
+  the conformance report's `**Excluded here:**` line. Revisit on a yuku bump: re-add
+  the row and run `deno task bench:conformance`.
 - **The oxc WASI binding's `errors` getter is CONSUME-ONCE.** On
   `@oxc-parser/binding-wasm32-wasi`, the first access to `result.errors`
   returns the real error array; every later access returns `[]` (the native

--- a/benches/js/bench.ts
+++ b/benches/js/bench.ts
@@ -786,7 +786,8 @@ async function run_preflight_group(
 	log(`\n· ${group_name}`);
 
 	const tasks = get_benchmark_tasks(impls, operation, language, {
-		forced_async: BENCH_FORCED_ASYNC
+		forced_async: BENCH_FORCED_ASYNC,
+		corpus_kind: CORPUS_MODE
 	});
 	await run_preflight(tasks, files, language);
 
@@ -1327,6 +1328,16 @@ function generate_markdown_report(
 	];
 	version_parts.push(...alternative_version_parts(versions));
 	lines.push(`**Versions:** ${version_parts.join(', ')}\n`);
+
+	// A row absent from a coverage report reads as "not measured"; say why.
+	if (IS_CONFORMANCE) {
+		lines.push(
+			'**Excluded here:** yuku-parser (N-API) — its native binding faults the host process on ' +
+				'this corpus (test262 escaped-identifier fixtures), so it cannot be measured against it. ' +
+				'The WASM binding runs the same engine and carries the row; both are measured on the perf ' +
+				'corpus.\n'
+		);
+	}
 
 	lines.push(
 		'**Methodology:** Single-threaded — every implementation formats/parses one file at a time, ' +

--- a/benches/js/lib/implementations.ts
+++ b/benches/js/lib/implementations.ts
@@ -245,6 +245,13 @@ export interface BenchmarkTaskOptions {
 	 * re-confirmation tool, not a standing measurement.
 	 */
 	forced_async?: boolean;
+	/**
+	 * Which corpus/surface this run measures (default `perf`). Only one task reads
+	 * it — the `yuku-parser` N-API row, dropped on the `conformance` surface
+	 * because that corpus carries inputs its native binding cannot survive. See the
+	 * registration site and CLAUDE.md §Known Issues.
+	 */
+	corpus_kind?: 'perf' | 'conformance';
 }
 
 /**
@@ -377,8 +384,14 @@ export function get_benchmark_tasks(
 		// forces yuku's LAZY materialization and reads its diagnostics — without
 		// either, the row would report an unearned throughput at a fabricated 100%
 		// coverage. See lib/yuku.ts + CLAUDE.md §Fairness Caveats.
+		//
+		// ⚠ The N-API row is CONFORMANCE-EXCLUDED: yuku's native binding SEGFAULTS
+		// the host process on that corpus's escaped-identifier test262 fixtures, so
+		// keeping it there would kill every run rather than score a rejection. The
+		// WASM binding is memory-safe and carries the engine on that surface. Both
+		// rows stay on the perf corpus, which contains no such input. See lib/yuku.ts.
 		add(
-			impls.yuku?.supports_parse_language(language),
+			impls.yuku?.supports_parse_language(language) && options.corpus_kind !== 'conformance',
 			'yuku-parser',
 			'yuku',
 			(source, _language, goal) => impls.yuku!.parse(source, language, goal)

--- a/benches/js/lib/yuku.ts
+++ b/benches/js/lib/yuku.ts
@@ -21,6 +21,23 @@
  * result buffer back out — a boundary tax of the same shape `tsv_wasm` pays, and
  * the reason that row belongs beside `tsv_wasm-json` and `oxc-parser-wasm` rather
  * than beside the native ones.
+ *
+ * ⚠ **The native binding is not memory-safe on adversarial input, so the N-API row
+ * is excluded from the CONFORMANCE surface** (`get_benchmark_tasks`). An identifier
+ * built from a long run of BRACED unicode escapes — `var _` + `'\u{11A01}'` ×75,
+ * i.e. once the decoded identifier passes ~300 bytes — SEGFAULTS the host process
+ * inside the Zig parse call; one escape fewer throws an ordinary `ParseFailed`.
+ * Non-braced escapes (`\uXXXX`) and literal non-ASCII identifiers are unaffected at
+ * any length, as is the wasm binding (the overrun stays inside linear memory, and
+ * it parses the same inputs cleanly). test262's
+ * `language/identifiers/part-unicode-*-{,class-}escaped.js` fixtures are exactly
+ * this shape, and they live only in the conformance corpus — real code has no such
+ * identifiers, so both rows stay on the perf corpus.
+ *
+ * A skip list is NOT a workaround here: which files of that family fault is
+ * heap-layout dependent (a sweep that skipped the 17 observed crashers faulted on
+ * an 18th that had survived the same sweep), so screening can neither be cached nor
+ * graded reproducibly. The exclusion is the whole row, and the report says so.
  */
 
 import { BaseImplementation, type Language, type ParseGoal } from './types.ts';


### PR DESCRIPTION
Yuku segfaults on some test262 tests, this fixes the harness to run only its wasm build for conformance.